### PR TITLE
Add authentication and authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .gradle
 build/
 
+#Ignore Eclipse generated files
+.classpath
+.project
+.settings/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - curl -i -u guest:guest -H "content-type:application/json"     -XPUT -d'{"type":"topic","durable":true}'     http://127.0.0.1:15672/api/exchanges/%2f/eiffel.test
 
 script:
-  - ./gradlew test integrationTest
+  - ./gradlew test integrationTest --stacktrace
 
 after_success:
 - ./gradlew jacocoTestReport coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
+## 0.1.9
+- added optional authentication to an Active Directory server for all 
+  REST endpoints
+
+
 ## 0.1.8
 - Improved error handling/logging

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ task integrationTest(type: Test) {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    compile('com.jayway.restassured:rest-assured:2.3.2')
+    compile('com.jayway.restassured:rest-assured:2.9.0')
     compile('org.yaml:snakeyaml:1.8')
     // The production code uses the SLF4J logging API at compile time
     compile 'org.slf4j:slf4j-api:1.7.18'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 
 war {
     baseName = 'remrem-publish'
-    version =  '0.1.8'
+    version =  '0.1.9'
 }
 
 apply plugin: 'spring-boot'
@@ -107,10 +107,16 @@ dependencies {
     //commons CLI
     compile 'commons-cli:commons-cli:1.3.1'
 
+    //Authentication
+    compile("org.springframework.boot:spring-boot-starter-security")
+    compile("org.springframework.security:spring-security-ldap")
+    compile("org.apache.directory.server:apacheds-server-jndi:1.5.5")
+
     //ServletException requires compile time servlet dependency but it causes problems
     //when deployed if exist on war run time.. hence provided but also compileOnly
     compileOnly("org.springframework.boot:spring-boot-starter-tomcat")
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
+    testCompile("org.springframework.boot:spring-boot-starter-tomcat")
 
     compile 'io.springfox:springfox-swagger2:2.4.0'
     compile 'io.springfox:springfox-swagger-ui:2.4.0'

--- a/src/integration-test/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
+++ b/src/integration-test/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.ericsson.eiffel.remrem.publish.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+@Profile("integration-test")
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+                .inMemoryAuthentication()
+                .withUser("user")
+                .password("secret")
+                .roles("USER");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                    .anyRequest()
+                    .authenticated()
+                    .and()
+                .httpBasic()
+                    .and()
+                .csrf()
+                    .disable();
+    }
+}

--- a/src/integration-test/java/com/ericsson/eiffel/remrem/publish/config/TestSecurityConfig.java
+++ b/src/integration-test/java/com/ericsson/eiffel/remrem/publish/config/TestSecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 @Profile("integration-test")
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class TestSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth

--- a/src/integration-test/resources/application.yml
+++ b/src/integration-test/resources/application.yml
@@ -1,5 +1,8 @@
 rabbitmq:
   host: 150.132.35.5
+  port:
+  user:
+  password:
   exchange:
     name: eiffel.test
 spring:

--- a/src/integration-test/resources/application.yml
+++ b/src/integration-test/resources/application.yml
@@ -8,3 +8,7 @@ rabbitmq:
 spring:
   http.converters:
     preferred-json-mapper: gson
+activedirectory:
+  enabled: true
+  domain:
+  url:

--- a/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
@@ -1,15 +1,19 @@
 package com.ericsson.eiffel.remrem.publish.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
 
-// TODO Uncomment to enable AD backed security
-//@Profile("!integration-test")
-//@Configuration
-//@EnableWebSecurity
+@Profile("!integration-test")
+@ConditionalOnProperty(prefix = "activedirectory.", value = "enabled")
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${activedirectory.domain")
     private String domain;

--- a/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.ericsson.eiffel.remrem.publish.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
+
+// TODO Uncomment to enable AD backed security
+//@Profile("!integration-test")
+//@Configuration
+//@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Value("${activedirectory.domain")
+    private String domain;
+
+    @Value("${activedirectory.url}")
+    private String url;
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        ActiveDirectoryLdapAuthenticationProvider activeDirectoryLdapAuthenticationProvider = new
+                ActiveDirectoryLdapAuthenticationProvider(domain, url);
+
+        auth.authenticationProvider(activeDirectoryLdapAuthenticationProvider);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                    .anyRequest()
+                    .authenticated()
+                    .and()
+                .httpBasic()
+                    .and()
+                .csrf()
+                    .disable();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   http.converters:
     preferred-json-mapper: gson
 
-# TODO Actual values for domain and url need to be provided
 activedirectory:
-  domain: "ERICSSON.COM"
-  url: "ldap://<hostname>.ericsson.com"
+  enabled: false
+  domain:
+  url:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,8 @@ rabbitmq:
 spring:
   http.converters:
     preferred-json-mapper: gson
+
+# TODO Actual values for domain and url need to be provided
+activedirectory:
+  domain: "ERICSSON.COM"
+  url: "ldap://<hostname>.ericsson.com"


### PR DESCRIPTION
Adds support and configuration for authenticating against an Active Directory server but does not enable it.
HTTP Basic authentication is applied to all REST endpoints. It means a request must contain an Authorization header with username:password base64 encoded. Using curl it's enough to add the option -u username:password.