### PR TITLE
Updated remrem-shared version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.7
+- Updated remrem-shared version to 0.3.2 to support base64 encryption functionality for Ldap manager password.
+
 ## 0.3.6
 - Added validation for 503 status code to check routing key as null.
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ subprojects {
     apply plugin: 'java'
 
     //Latest version for publish
-    version = "0.3.6"
+    version = "0.3.7"
 
     //Declare where to find the dependencies of project here
     repositories {
@@ -95,7 +95,7 @@ subprojects {
         compile 'org.apache.commons:commons-lang3:3.5'
         
         //Injectable Message Library and its Implementation
-        compile 'com.github.Ericsson:eiffel-remrem-shared:0.3.1'
+        compile 'com.github.Ericsson:eiffel-remrem-shared:0.3.2'
         compile 'com.github.Ericsson:eiffel-remrem-protocol-interface:0.0.1'
         //For publishing eiffel2.0 events
         compile("com.github.Ericsson:eiffel-remrem-semantics:0.2.3"){

--- a/publish-common/src/main/resources/config.properties
+++ b/publish-common/src/main/resources/config.properties
@@ -28,6 +28,7 @@
 #Ldap authentication configurations
   activedirectory.enabled: false
   activedirectory.ldapUrl : 
-  activedirectory.ldapPassword :
+  activedirectory.managerPassword :
   activedirectory.managerDn:
+  activedirectory.rootDn:
   activedirectory.userSearchFilter:


### PR DESCRIPTION
Implemented base64 encryption functionality for ldap manager password in remrem-shared

- added rootDn property in ldap configurations

- variable name changed from ldapPassword to managerPassword