### PR TITLE
uplifted remrem-shared version to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.8
 - Added copyright headers to the source code.
+- Uplifted remrem-shared version to 0.3.3 to get the versions of publish and all loaded protocols.
 
 ## 0.3.7
 - Updated remrem-shared version to 0.3.2 to support base64 encryption functionality for Ldap manager password.

--- a/build.gradle
+++ b/build.gradle
@@ -109,10 +109,10 @@ subprojects {
         compile 'org.apache.commons:commons-lang3:3.5'
         
         //Injectable Message Library and its Implementation
-        compile 'com.github.Ericsson:eiffel-remrem-shared:0.3.2'
+        compile 'com.github.Ericsson:eiffel-remrem-shared:0.3.3'
         compile 'com.github.Ericsson:eiffel-remrem-protocol-interface:0.0.1'
         //For publishing eiffel2.0 events
-        compile("com.github.Ericsson:eiffel-remrem-semantics:0.2.3"){
+        compile("com.github.Ericsson:eiffel-remrem-semantics:0.2.5"){
                 exclude group: 'org.apache.commons'
         }
         

--- a/publish-cli/build.gradle
+++ b/publish-cli/build.gradle
@@ -17,6 +17,11 @@ apply plugin: 'application'
 //To create executable CLI jar
 jar {
     baseName = 'publish-cli'
+   manifest {
+        attributes('Main-Class': 'com.ericsson.eiffel.remrem.publish.cli.CLI')
+        attributes('remremVersionKey': 'serviceVersion')
+        attributes('serviceVersion': version)
+    }
 }
 
 //This task is used for spring boot repackaging

--- a/publish-cli/src/main/java/com/ericsson/eiffel/remrem/publish/cli/CliOptions.java
+++ b/publish-cli/src/main/java/com/ericsson/eiffel/remrem/publish/cli/CliOptions.java
@@ -15,6 +15,7 @@
 package com.ericsson.eiffel.remrem.publish.cli;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -27,6 +28,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
+import com.ericsson.eiffel.remrem.shared.VersionService;
 
 public class CliOptions {
 	
@@ -77,6 +79,7 @@ public class CliOptions {
         options.addOption("mp", "messaging_protocol", true, "name of messaging protocol to be used, e.g. eiffel3, eiffelsemantics, default is eiffelsemantics");
         options.addOption("domain", "domainId", true, "identifies the domain that produces the event");
         options.addOption("ud", "user_domain_suffix", true, "user domain suffix");
+        options.addOption("v", "lists the versions of publish and all loaded protocols");
         contentGroup = createContentGroup();
         options.addOptionGroup(contentGroup);
     }
@@ -124,7 +127,9 @@ public class CliOptions {
         if (commandLine.hasOption("h")) {
     	    System.out.println("You passed help flag.");
     	    help(0);
-        } else {
+        } else if (commandLine.hasOption("v")) {
+            printVersions();
+        }else {
             checkRequiredOptions();
         }
     }
@@ -263,5 +268,29 @@ public class CliOptions {
         addErrorCode(errorCode);
       else
         System.exit(errorCode);
+    }
+    
+    /**
+     * Lists the versions of publish and all loaded protocols  
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void printVersions() {
+        Map versions = new VersionService().getMessagingVersions();
+        Map<String, String> endpointVersions = (Map<String, String>) versions.get("endpointVersions");
+        Map<String, String> serviceVersion = (Map<String, String>) versions.get("serviceVersion");
+
+        if(serviceVersion != null) {
+            System.out.print("REMReM Publish version ");
+            for (String version: serviceVersion.values()) {
+                System.out.println(version);
+            }
+        }
+        if(endpointVersions != null) {
+            System.out.println("Available endpoints");
+            for (Map.Entry<String, String> entry : endpointVersions.entrySet()) {
+                System.out.println(entry);
+            }
+        }
+        exit(0);
     }
 }

--- a/publish-service/build.gradle
+++ b/publish-service/build.gradle
@@ -20,6 +20,11 @@ plugins {
 //This task creates the executable service war
 war {
     baseName = 'publish-service'
+    manifest {
+        attributes('Main-Class': 'com.ericsson.eiffel.remrem.publish.service.App')
+        attributes('remremVersionKey': 'serviceVersion')
+        attributes('serviceVersion': version)
+    }
 }
 
 //JacocoReport task can be used to generate code coverage reports in different formats

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -14,6 +14,8 @@
 */
 package com.ericsson.eiffel.remrem.publish.controller;
 
+import java.util.Map;
+
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,12 +31,14 @@ import com.ericsson.eiffel.remrem.protocol.MsgService;
 import com.ericsson.eiffel.remrem.publish.helper.PublishUtils;
 import com.ericsson.eiffel.remrem.publish.service.MessageService;
 import com.ericsson.eiffel.remrem.publish.service.SendResult;
+import com.ericsson.eiffel.remrem.shared.VersionService;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 import ch.qos.logback.classic.Logger;
 
 @RestController
-@RequestMapping("/producer")
+@RequestMapping("/*")
 public class ProducerController {
 
     @Autowired
@@ -45,7 +49,7 @@ public class ProducerController {
     Logger log = (Logger) LoggerFactory.getLogger(ProducerController.class);
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @RequestMapping(value = "/msg", method = RequestMethod.POST)
+    @RequestMapping(value = "/producer/msg", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity send(@RequestParam(value = "mp", required = false) String msgProtocol,
             @RequestParam(value = "ud", required = false) String userDomain, @RequestBody JsonElement body) {
@@ -55,5 +59,15 @@ public class ProducerController {
         log.debug("body: " + body);
         SendResult result = messageService.send(body, msgService, userDomain);
         return new ResponseEntity(result, messageService.getHttpStatus());
+    }
+    
+    /**
+     * @return this method returns the current version of publish and all loaded protocols.
+     */
+    @RequestMapping(value = "/versions", method = RequestMethod.GET)
+    public JsonElement getVersions() {
+        JsonParser parser = new JsonParser();
+        Map<String, Map<String, String>> versions = new VersionService().getMessagingVersions();
+        return parser.parse(versions.toString());
     }
 }


### PR DESCRIPTION
1. Added one more option (-v) in CLI to print versions of publish and all loaded protocols.
2. Uplifted shared version to 0.3.3 to get versions.
3. Uplifted semantics version to 0.2.5.