### PR TITLE
Uplift remrem semantics to 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.5
+- Uplifted remrem-semantics version to 0.2.8.
+
+## 0.4.4
+- Uplifted remrem-semantics version to 0.2.7.
+
 ## 0.4.3
 - Removed spring configurations from config.properties file and handled through code.
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects {
     apply plugin: 'java'
 
     //Latest version for publish
-    version = "0.4.4"
+    version = "0.4.5"
 
     //Declare where to find the dependencies of project here
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ subprojects {
         compile 'com.github.Ericsson:eiffel-remrem-shared:0.3.4'
         compile 'com.github.Ericsson:eiffel-remrem-protocol-interface:0.0.1'
         //For publishing eiffel2.0 events
-        compile("com.github.Ericsson:eiffel-remrem-semantics:0.2.7"){
+        compile("com.github.Ericsson:eiffel-remrem-semantics:0.2.8"){
                 exclude group: 'org.apache.commons'
         }
         


### PR DESCRIPTION
Uplift remrem semantics to 0.2.8, because remrem-generate and remrem-publish must use the same versions of their dependencies.