### PR TITLE
Restructured REMReM Publish documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+.idea/
+gradle/
+gradlew
+gradlew.bat

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -123,7 +123,7 @@ usage: java -jar
         </ul>
         <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -tls 1.2</code></pre>
 
-        <p><strong>NOTE:</strong> for RabbitMQ default port 5672, no need to pass tls option.</p>
+        <p><strong>NOTE:</strong> for RabbitMQ default port 5672, no need to pass -tls option.</p>
 
         <h5>If you want to have the message publishing on RabbitMQ with given routing key:</h5>
         <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -rk myroutingkey</code></pre>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -18,7 +18,7 @@
     <header class="inner">
         <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
 
-        <h1><a class="project_title" href="index.html#project_title"></a>Eiffel REMReM Publish</h1>
+        <h1><a class="project_title" href="index.html">Eiffel REMReM Publish</a></h1>
 
         <section id="downloads">
             <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
@@ -36,11 +36,6 @@
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>REMReM Publish CLI
         </h1>
-
-        <p>REMReM (<strong>REST Mailbox for Registered Messages</strong>) is a set of tools that can be used to generate validated Eiffel messages and
-            publish them on a RabbitMQ message bus. They can be run as micro services or as stand-alone CLI versions. For more details on the micro
-            services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">https://github.com/Ericsson/eiffel-remrem</a>
-        </p>
 
         <h2>
             <a id="usage" class="anchor" href="#usage" aria-hidden="true">
@@ -95,7 +90,8 @@ usage: java -jar
             separated by comma.</p>
 
         <p>The routing key is generated in the protocol library based on the event type.<br>
-            To get more information on routing key see <a href="http://ericsson.github.io/eiffel-remrem-semantics/" target="_blank">here</a>.
+            To get more information on routing key see
+            <a href="http://ericsson.github.io/eiffel-remrem-semantics/routingAndBindingKeyConcepts.html" target="_blank">here</a>.
         </p>
 
         <h2>
@@ -134,6 +130,24 @@ usage: java -jar
 
         <h5>If you want to have the message publishing on RabbitMQ with given tag:</h5>
         <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -tag production</code></pre>
+
+        <p>Typical output for these examples is:</p>
+<pre>[
+  {
+    "id": "963da060-f2cf-4370-a68d-67fd872def36",
+    "status_code": 200,
+    "result": "SUCCESS",
+    "message": "Event sent successfully"
+  }
+]</pre>
+
+        <h2>
+            <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Status Codes
+        </h2>
+
+        <p>To get information about internal status codes see <a href="statusCodes.html">here</a>.</p>
 
     </section>
 </div>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -147,6 +147,7 @@ usage: java -jar
             </a>Status Codes
         </h2>
 
+        <p>For each user request Eiffel REMReM Publish generate response in JSON with internal status code and message.</p>
         <p>To get information about internal status codes see <a href="statusCodes.html">here</a>.</p>
 
     </section>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -112,6 +112,10 @@ usage: java -jar
         <pre><code>java -Djava.ext.dirs="/path/to/jars/" -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp protocolType</code></pre>
 
         <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+        <p><strong>NOTE:</strong> <code>-Djava.ext.dirs</code> is no longer working in some JAVA8 versions and in JAVA9.
+            So users should create a wrapper project to include both Generate/Publish and their protocol in
+            or place the protocol library in the folder for external dependencies of their JVM installation.
+        </p>
 
         <h5>If you want to have the message publishing logs add d flag:</h5>
         <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -d</code></pre>
@@ -142,12 +146,49 @@ usage: java -jar
 ]</pre>
 
         <h2>
+            <a id="exitCodes" class="anchor" href="#exitCodes" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Exit Codes
+        </h2>
+        <p>If CLI fails internally before trying to publish Eiffel message, user will get exit code. Exit codes are described in the table below.</p>
+
+        <table class="wikitable">
+            <tr>
+                <th style="text-align: left;">Exit code</th>
+                <th style="text-align: left;">Description</th>
+            <tr>
+                <td>1</td>
+                <td>User will get this exit code in case of some error that is not described below</td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>Some CLI options are missed</td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>Passed message protocol or message bus configuration are not correct</td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>Passed file path is wrong. File is not found</td>
+            </tr>
+            <tr>
+                <td>5</td>
+                <td>Unable to read content from passed file path</td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>Unable to read passed JSON string from command line</td>
+            </tr>
+        </table>
+
+        <h2>
             <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Status Codes
         </h2>
 
-        <p>For each user request Eiffel REMReM Publish generate response in JSON with internal status code and message.</p>
+        <p>For each user request Eiffel REMReM Publish generate response in JSON with internal status code and message, when publishing takes place.</p>
         <p>To get information about internal status codes see <a href="statusCodes.html">here</a>.</p>
 
     </section>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="description" content="Eiffel RemRem Publish Service : ">
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+
+    <title>Eiffel REMReM Publish</title>
+</head>
+
+<body>
+
+<!-- HEADER -->
+<div id="header_wrap" class="outer">
+    <header class="inner">
+        <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
+
+        <h1><a class="project_title" href="index.html#project_title"></a>Eiffel REMReM Publish</h1>
+
+        <section id="downloads">
+            <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
+            <a class="tar_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/tarball/master">Download this project as a tar.gz file</a>
+        </section>
+    </header>
+</div>
+
+<!-- MAIN CONTENT -->
+<div id="main_content_wrap" class="outer">
+    <section id="main_content" class="inner">
+
+        <h1>
+            <a id="remrem-publish-cli" class="anchor" href="#remrem-publish-cli" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>REMReM Publish CLI
+        </h1>
+
+        <p>REMReM (<strong>REST Mailbox for Registered Messages</strong>) is a set of tools that can be used to generate validated Eiffel messages and
+            publish them on a RabbitMQ message bus. They can be run as micro services or as stand-alone CLI versions. For more details on the micro
+            services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">https://github.com/Ericsson/eiffel-remrem</a>
+        </p>
+
+        <h2>
+            <a id="usage" class="anchor" href="#usage" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Usage
+        </h2>
+
+        <p>For using Eiffel REMReM Publish CLI self executing <strong>publish-cli.jar</strong> file should be executed in command line with parameters described below.</p>
+
+        <pre>$ java -jar publish-cli.jar -h
+
+You passed help flag.
+usage: java -jar
+
+-d,--debug                        Enable debug traces.
+
+-domain,--domainId &lt;arg&gt;          Identifies the domain that produces the event.
+
+-en,--exchange_name &lt;arg&gt;         Exchange name.
+
+-f,--content_file &lt;arg&gt;           Event content file.
+
+-h,--help                         Show help.
+
+-json,--json_content &lt;arg&gt;        Event content in JSON string. The value can also be a dash (-)
+                                  and the JSON will be read from the output of other programs if piped.
+                                  Multiple JSON events are also supported.
+
+-mb,--message_bus &lt;arg&gt;           Host of message bus to use.
+
+-mp,--message_protocol &lt;arg&gt;      Name of messaging protocol to be used, e.g. eiffel3, eiffelsemantics.
+                                  Default is eiffelsemantics.
+
+-np,--non_persistent              Remove persistence from message sending.
+
+-tls,--tls &lt;arg&gt;                  tls version, specify a valid tls version: '1', '1.1', '1.2' or default.
+                                  It is required for RabbitMQ secured port (5671).
+
+-port,--port &lt;arg&gt;                Port to connect to message bus, default is 5672.
+
+-ud,--user_domain_suffix &lt;arg&gt;    User domain suffix.
+
+-rk,--routing_key &lt;arg&gt;           Routing key of the eiffel message.
+                                  When provided routing key is not generated and the value provided is used.
+
+-tag,--tag &lt;arg&gt;                  Tag to be used in routing key.
+
+-v,--list_versions                Lists the versions of publish and all loaded protocols.
+        </pre>
+
+        <p>For publish we have input only from file that can contain one or more messages in a JSON array (surrounded with square brackets)
+            separated by comma.</p>
+
+        <p>The routing key is generated in the protocol library based on the event type.<br>
+            To get more information on routing key see <a href="http://ericsson.github.io/eiffel-remrem-semantics/" target="_blank">here</a>.
+        </p>
+
+        <h2>
+            <a id="examples" class="anchor" href="#examples" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples
+        </h2>
+
+        <p>Typical examples of usage Eiffel REMReM Publish CLI are described below.</p>
+
+        <h5>Publish on a given host, given exchange, given domain and given user domain suffix:</h5>
+        <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb101 -domain eiffel001 -ud fem001 -mp eiffelsemantics</code></pre>
+
+        <h5>If you want to have the message non persistent add np flag:</h5>
+        <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -np -mp eiffelsemantics</code></pre>
+
+        <h5>For loading protocol jars other than eiffelsemantics:</h5>
+        <pre><code>java -Djava.ext.dirs="/path/to/jars/" -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp protocolType</code></pre>
+
+        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+
+        <h5>If you want to have the message publishing logs add d flag:</h5>
+        <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -d</code></pre>
+
+        <h5>If you want to have the message publishing on RabbitMQ secured port (5671):</h5>
+        <ul>
+            <li>tls option is used to run REMReM on RabbitMQ secured port (5671).</li>
+            <li>tls option value is either 'default' or &lt;version&gt; for secured port.</li>
+        </ul>
+        <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -tls 1.2</code></pre>
+
+        <p><strong>NOTE:</strong> for RabbitMQ default port 5672, no need to pass tls option.</p>
+
+        <h5>If you want to have the message publishing on RabbitMQ with given routing key:</h5>
+        <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -rk myroutingkey</code></pre>
+
+        <h5>If you want to have the message publishing on RabbitMQ with given tag:</h5>
+        <pre><code>java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -tag production</code></pre>
+
+    </section>
+</div>
+
+<!-- FOOTER  -->
+<div id="footer_wrap" class="outer">
+    <footer class="inner">
+        <p class="copyright">Eiffel REMReM Publish maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/cliUsage.html
+++ b/cliUsage.html
@@ -66,7 +66,7 @@ usage: java -jar
 
 -mb,--message_bus &lt;arg&gt;           Host of message bus to use.
 
--mp,--message_protocol &lt;arg&gt;      Name of messaging protocol to be used, e.g. eiffel3, eiffelsemantics.
+-mp,--message_protocol &lt;arg&gt;      Name of messaging protocol to be used, e.g: eiffelsemantics.
                                   Default is eiffelsemantics.
 
 -np,--non_persistent              Remove persistence from message sending.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Eiffel RemRem Publish Service : ">
 
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+    <script type="text/javascript" src="javascripts/download.js"></script>
 
     <title>Eiffel REMReM Publish</title>
 </head>
@@ -82,37 +83,6 @@
         </p>
 
         <div id="downloadLink" style="visibility: hidden;color: red;font-size: 14px;"></div>
-        <script type="text/javascript">
-             function getLatestVersion(type,extn) {
-                 var xhr = new XMLHttpRequest();
-                 xhr.open("GET", "https://jitpack.io/v/Ericsson/eiffel-remrem-publish.svg");
-                 xhr.responseType = "blob";//force the HTTP response, response-type header to be blob
-                 xhr.onload = function() {
-                    var blob = xhr.response;
-                    var reader = new FileReader();
-                    reader.addEventListener("loadend", function() {
-                        var result = reader.result;
-                        if(result=="Repo not found or no access token provided"){
-                            document.getElementById("downloadLink").innerHTML = result;
-                            document.getElementById("downloadLink").style.visibility = "";
-                        } else {
-                            document.getElementById("downloadLink").innerHTML = result;
-                            var val = document.getElementsByTagName("text")[2].innerHTML;
-                            val = val.trim();
-                            urlLink = "https://jitpack.io/com/github/Ericsson/eiffel-remrem-publish/publish-"+type +"/"+val+"/publish-"+type +"-"+val+"."+extn;
-                            var link = document.createElement("a");
-                            link.setAttribute('id',"MYLINK");
-                            link.href = urlLink;
-                            document.body.appendChild(link);
-                            link.setAttribute("type", "hidden");
-                            link.click();
-                        }
-                    });
-                    reader.readAsBinaryString(blob);
-                 }
-                 xhr.send();
-             }
-        </script>
 
         <h2>
             <a id="usage" class="anchor" href="#usage" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <header class="inner">
         <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
 
-        <h1><a class="project_title" href="index.html#project_title"></a>Eiffel REMReM Publish</h1>
+        <h1><a class="project_title" href="index.html">Eiffel REMReM Publish</a></h1>
 
         <section id="downloads">
             <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
@@ -75,10 +75,10 @@
         <pre>./gradlew build</pre>
         <p>Binary is released via <a href="https://jitpack.io/#Ericsson/eiffel-remrem-publish">jitPack</a>.</p>
         <p>The latest REMReM Publish CLI binary can be downloaded via
-            <a onClick="getLatestVersion('cli','jar');" href="#">publish-cli.jar</a>.
+            <a onClick="getLatestVersion('cli','jar');" href="#installation">publish-cli.jar</a>.
         </p>
         <p>The latest REMReM Publish Service binary can be downloaded via
-            <a onClick="getLatestVersion('service','war');" href="#">publish-service.war</a>.
+            <a onClick="getLatestVersion('service','war');" href="#installation">publish-service.war</a>.
         </p>
 
         <div id="downloadLink" style="visibility: hidden;color: red;font-size: 14px;"></div>
@@ -125,6 +125,7 @@
         <p>To get information about configuration and usage of <strong>REMReM Publish Service</strong> see
             <a href="serviceUsage.html">here</a>.
         </p>
+        <p>To get information about internal status codes see <a href="statusCodes.html">here</a>.</p>
 
         <h2>Logging</h2>
         <p>REMReM Publish application logging is implemented using the logback-classic. It requires user to configure the logback.xml file.<br>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <header class="inner">
         <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
 
-        <h1 id="project_title">Eiffel REMReM Publish</h1>
+        <h1><a class="project_title" href="index.html#project_title"></a>Eiffel REMReM Publish</h1>
 
         <section id="downloads">
             <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
@@ -30,52 +30,57 @@
 <!-- MAIN CONTENT -->
 <div id="main_content_wrap" class="outer">
     <section id="main_content" class="inner">
-        <p>REMReM (<strong>REST Mailbox for Registered Messages</strong>) is a set of tools that can be used to generate validated Eiffel messages and
-            publish them on a RabbitMQ message bus. They can be run as micro services or as stand-alone CLI versions. For more details on the micro
-            services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">https://github.com/Ericsson/eiffel-remrem</a>
-        </p>
-
-        <h1>
-            <a id="remrem-publish" class="anchor" href="#remrem-publish" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>REMReM Publish
-        </h1>
-
-        <hr>
 
         <h2>
-            <a id="components" class="anchor" href="#components" aria-hidden="true">
+            <a id="introduction" class="anchor" href="#introduction" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Components
+            </a>Introduction
         </h2>
-
-        <ul>
-            <li>REMReM Publish CLI (Command Line Interface)</li>
-            <li>REMReM Publish Service</li>
-        </ul>
+        <p>REMReM (<strong>REST Mailbox for Registered Messages</strong>) is a set of tools that can be used to generate validated Eiffel messages and
+            publish them on a RabbitMQ message bus. They can be run as micro services or as stand-alone CLI versions. For more details on the micro
+            services and the REMReM design, see <a href="https://github.com/Ericsson/eiffel-remrem">Eiffel REMReM</a>.
+        </p>
+        <p>Eiffel REMReM Publish is a tool that can be used to publish Eiffel messages on a RabbitMQ message bus.</p>
 
         <h2>
             <a id="compatibility" class="anchor" href="#compatibility" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Compatibility
         </h2>
-
         <ul>
             <li>JDK 8</li>
             <li>Tomcat 8</li>
+            <li>RabbitMQ Server 3.6.x</li>
         </ul>
-
-        <hr>
+        <p>For supporting latest features, Eiffel REMReM Publish should use the latest version of
+            <a href="http://ericsson.github.io/eiffel-remrem-semantics/">Eiffel REMReM Semantics</a>.
+        </p>
 
         <h2>
-            <a id="how-to-install" class="anchor" href="#how-to-install" aria-hidden="true">
+            <a id="components" class="anchor" href="#components" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>How to Install?
+            </a>Components
         </h2>
+        <ul>
+            <li>REMReM Publish CLI (Command Line Interface)</li>
+            <li>REMReM Publish Service</li>
+        </ul>
 
-        <p>Binary is released via <a href="https://jitpack.io/#Ericsson/eiffel-remrem-publish">jitPack</a></p>
-        <p>Download the latest REMReM Publish CLI Binary via <a onClick="getLatestVersion('cli','jar');" href="#">publish-cli.jar</a></p>
-        <p>Download the latest REMReM Publish Service Binary via <a onClick="getLatestVersion('service','war');" href="#">publish-service.war</a></p>
+        <h2>
+            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Installation
+        </h2>
+        <p>Eiffel REMReM Publish is gradle project and can be built by executing following command:</p>
+        <pre>./gradlew build</pre>
+        <p>Binary is released via <a href="https://jitpack.io/#Ericsson/eiffel-remrem-publish">jitPack</a>.</p>
+        <p>The latest REMReM Publish CLI binary can be downloaded via
+            <a onClick="getLatestVersion('cli','jar');" href="#">publish-cli.jar</a>.
+        </p>
+        <p>The latest REMReM Publish Service binary can be downloaded via
+            <a onClick="getLatestVersion('service','war');" href="#">publish-service.war</a>.
+        </p>
+
         <div id="downloadLink" style="visibility: hidden;color: red;font-size: 14px;"></div>
         <script type="text/javascript">
              function getLatestVersion(type,extn) {
@@ -109,581 +114,29 @@
              }
         </script>
 
-        <h3>
-            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Installation (Micro service)
-        </h3>
-
-        <p>Start the self executing JAR</p>
-        <pre>java -jar publish-cli.jar</pre>
-
-        <hr>
-
         <h2>
-            <a id="usage-cli-command-line-interface" class="anchor" href="#usage-cli-command-line-interface" aria-hidden="true">
+            <a id="usage" class="anchor" href="#usage" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Usage CLI (Command Line Interface)
+            </a>Usage
         </h2>
-
-        <pre>$ java -jar publish-cli.jar -h
-You passed help flag.
-usage: java -jar
--d,--debug                     enable debug traces
--domain,--domainId &lt;arg&gt;       identifies the domain that produces the event.
--en,--exchange_name &lt;arg&gt;      exchange name
--f,--content_file &lt;arg&gt;        event content file
--h,--help                      show help.
--json,--json_content &lt;arg&gt;     event content in json string. The value can
-                               also be a dash(-) and the json will be read
-                               from the output of other programs if piped. Multiple
-                               json events are also supported.
--mb,--message_bus &lt;arg&gt;        host of message bus to use
--mp,--message_protocol &lt;arg&gt;   name of messaging protocol to be used, e.g. eiffel3,
-                               eiffelsemantics, default is eiffelsemantics
--np,--non_persistent           remove persistence from message sending
--tls,--tls &lt;arg&gt;               tls version, specify a valid tls version: '1', '1.1',
-                               '1.2' or default.
-                               It is required for RabbitMQ secured port(5671).
--port,--port &lt;arg&gt;             port to connect to message bus, default is 5672
--ud,--user_domain_suffix &lt;arg&gt; user domain suffix
--rk,--routing_key &lt;arg&gt;        routing key of the eiffel message. When provided
-                               routing key is not generated and the value provided is used.
--tag,--tag &lt;arg&gt;               tag to be used in routing key
--v,--list_versions             lists the versions of publish and all loaded protocols
-        </pre>
-
-        <p>For publish we have input only from file that can contain one or more messages in a JSON array (surrounded with square brackets)
-            separated by comma.</p>
-
-        <p>The routing key is generated in the protocol library based on the event type.<br>
-            For more information on routing key, see <a href="http://ericsson.github.io/eiffel-remrem-semantics/" target="_blank">this link</a>
+        <p>To get information about configuration and usage of <strong>REMReM Publish CLI</strong> see
+            <a href="cliUsage.html">here</a>.
         </p>
-
-        <p><strong>Publish on a given host, given exchange, given domain and given user domain suffix:</strong></p>
-        <pre><code>$ java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb101 -domain eiffel001 -ud fem001 -mp eiffelsemantics</code></pre>
-
-        <p><strong>If you want to have the message non persistent add np flag:</strong></p>
-        <pre><code>$ java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -np -mp eiffelsemantics</code></pre>
-
-        <p><strong>For loading protocol jars other than eiffelsemantics:</strong></p>
-        <pre><code>$ java -Djava.ext.dirs="/path/to/jars/" -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp protocolType</code></pre>
-
-        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
-
-        <p><strong>If you want to have the message publishing logs add d flag:</strong></p>
-        <pre><code>$ java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -d</code></pre>
-
-        <p><strong>If you want to have the message publishing on RabbitMQ secured port(5671):</strong><br>
-            tls option is used to run REMReM on RabbitMQ secured port(5671)<br>
-            tls option value is either 'default' or &lt;version&gt; for secured port.
+        <p>To get information about configuration and usage of <strong>REMReM Publish Service</strong> see
+            <a href="serviceUsage.html">here</a>.
         </p>
-        <pre><code>$ java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -tls 1.2</code></pre>
-
-        <p><strong>NOTE:</strong> for RabbitMQ default port 5672, no need to pass tls option.</p>
-
-        <p><strong>If you want to have the message publishing on RabbitMQ with given routing key:</strong></p>
-        <pre><code>$ java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -rk myroutingkey</code></pre>
-
-        <p><strong>If you want to have the message publishing on RabbitMQ with given tag:</strong></p>
-        <pre><code>$ java -jar publish-cli.jar -f publishMessages.json -en rabbit -mb mb123 -mp eiffelsemantics -tag production</code></pre>
-
-        <h2>
-            <a id="usage-service" class="anchor" href="#usage-service" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Usage service
-        </h2>
-
-        <p>REMReM Publish microservice allows for sending messages to a topic-based exchange on a RabbitMQ Server. It has an end point that must
-            be called using a relative link <code>producer/msg</code>.
-        </p>
-
-        <p>We can get information about the REMReM Publish Service all endpoints and easily access them from here:<br>
-            <em>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/</em> or <em>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/swagger-ui.html</em>
-        </p>
-
-        <h3>
-            <a id="installation" class="anchor" href="#installation" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Installation (Micro service)
-        </h3>
-
-        <p>Deploy the publish-service.war in Tomcat to use REST services.</p>
-
-        <h3>
-            <a id="configuration" class="anchor" href="#configuration" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Configuration
-        </h3>
-
-        <p>Configuration is done in tomcat using a config.properties file: tomcat/conf/config.properties</p>
-
-        <h3>Exchange configurations:</h3>
-
-        <p>These parameters need to be provided to start the service:</p>
-
-        <ul>
-            <li><code> &lt;protocol&gt;.rabbitmq.host (String)</code></li>
-            <li><code> &lt;protocol&gt;.rabbitmq.port (Optional)</code></li>
-            <li><code> &lt;protocol&gt;.rabbitmq.username (Optional)</code></li>
-            <li><code> &lt;protocol&gt;.rabbitmq.password (Optional)</code></li>
-            <li><code> &lt;protocol&gt;.rabbitmq.tls (Optional)</code></li>
-            <li><code> &lt;protocol&gt;.rabbitmq.exchangeName (String)</code></li>
-            <li><code> &lt;protocol&gt;.rabbitmq.domainId (String)</code></li>
-        </ul>
-
-        <p>An <a href="https://www.rabbitmq.com/tutorials/tutorial-three-java.html">exchange point</a> must exist before you start the service.</p>
-
-        <p><code>&lt;protocol&gt;</code> is name of the protocol used. Eg: eiffelsemantics.</p>
-
-        <p>For any protocol, need to configure above RabbitMQ properties in <strong>tomcat/conf/config.properties</strong> file.</p>
-        <p>classpath:config.properties file is for reference only. Will not pick any values from that file.</p>
-
-        <h3>Ldap configurations:</h3>
-
-        <p align="justify">Active Directory authentication can be enabled for the REMReM REST service by setting the configuration property
-            <code>activedirectory.publish.enabled=true</code>.
-        </p>
-
-        <p>To authenticate with active ldap server we have to provide the following configurations in the
-            <strong>tomcat/conf/config.properties</strong> file.
-        </p>
-
-        <pre>
-activedirectory.ldapUrl         : &lt;LDAP server url&gt;
-activedirectory.managerPassword : &lt;LDAP server manager password(must be base64 Encrypted format)&gt;
-activedirectory.managerDn       : &lt;LDAP managerDn pattern&gt;
-activedirectory.rootDn          : &lt;LDAP rootDn pattern&gt;
-activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;
-        </pre>
-
-        <p><strong> LDAP authentication without Base64 encryption:</strong></p>
-        <pre><code> $ curl -XPOST -H "Content-Type: application/json" --user username:password --data @ActivityCanceled.json http://localhost:8080/publish/producer/msg?mp=eiffelsemantics</code></pre>
-
-        <p align="justify">Each HTTP request must then include an Authorization header with value
-            <code>Basic &lt;Base64 encoded username:password&gt;</code>.
-        </p>
-
-        <p><strong>LDAP authentication with Base64 encryption:</strong></p>
-        <pre><code>$ curl -XPOST -H "Content-Type: application/json" -H 'Authorization: Basic cGFzc3dvcmQ=' --data @ActivityCanceled.json http://localhost:8080/publish/producer/msg?mp=eiffelsemantics</code></pre>
-
-        <p><strong>NOTE:</strong> assuming the publish-service is deployed in tomcat as publish.</p>
-
-        <h3>
-            <a id="rest-methods" class="anchor" href="#rest-methods" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>REST methods
-        </h3>
-
-        <p>The service works on the relative link <code>producer/msg</code> and supports POST requests.</p>
-
-        <p>You have to specify a user domain suffix using <code>ud</code> URL parameter.</p>
-
-        <p>You have to specify a messaging protocol using <code>mp</code> URL parameter.</p>
-
-        <p>The request's body must contain a <strong>JSON Object or JSON Array</strong> with the messages.</p>
-
-
-        <h3>GenerateAndPublish end point:</h3>
-
-        <p>The service works on the relative link <code>/generateAndPublish</code> if run as standalone application or
-            <code>/publish/generateAndPublish</code> if run as tomcat app and supports POST requests.<br>
-            This controller provides single REMReM REST API End Point for both REMReM Generate and Publish.
-        </p>
-
-        <p>Ex: <code>http://localhost:8080/generateAndPublish/</code></p>
-
-        <p>Parameters:<br>
-            * @param mp<br>
-            * @param message protocol (required)<br>
-            * @param msgType message type (required)<br>
-            * @param ud user domain (not required)<br>
-            * @param tag (not required)<br>
-            * @param rk (not required)<br>
-            * @return A response entity which contains https status and result
-        </p>
-
-        <strong>Usage: a typical CURL command:</strong>
-
-        <pre><code>curl -H "Content-Type: application/json" -X POST --data "@inputGenerate_activity_finished.txt"  "http://localhost:8986/publish/generateAndPublish/?mp=eiffelsemantics&msgType=EiffelActivityFinished"</code></pre>
-
-        <p>Where, "inputGenerate_activity_finished.txt" is:</p>
-
-        <pre>
-{
-  "msgParams": {
-    "meta": {
-      "type": "EiffelActivityFinishedEvent",
-      "tags": [
-        "tag1",
-        "tag2"
-      ],
-      "source": {
-        "domainId": "example.domain",
-        "host": "host",
-        "name": "name",
-        "uri": "http://java.sun.com/j2se/1.3/",
-        "gav": {
-          "groupId": "com.github.Ericsson",
-          "artifactId": "eiffel-remrem-semantics",
-          "version": "0.2.9"
-        }
-      },
-      "security": {
-        "sdm": {
-          "authorIdentity": "test",
-          "encryptedDigest": "sample"
-        }
-      }
-    }
-  },
-  "eventParams": {
-    "data": {
-      "outcome": {
-        "conclusion": "SUCCESSFUL"
-      },
-      "persistentLogs": [{
-        "name": "firstLog",
-        "uri": "http://myHost.com/firstLog"
-      },
-        {
-          "name": "otherLog",
-          "uri": "isbn:0-486-27557-4"
-        }
-      ]
-    },
-    "links": [
-      {
-        "type": "ACTIVITY_EXECUTION",
-        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
-      }
-    ]
-  }
-}       </pre>
-
-        <p>RESULT:<br>
-            A typical output of executing the above curl command with an arbitrary JSON:
-        </p>
-
-        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"},{"id":"963da060-f2cf-4370-a68d-67fd872dek89","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
-
-        <h3>Versions End point:</h3>
-        <p>"/versions" end point is used to get the versions of messaging protocols along with the current version of publish in a JSON format.<br>
-                URL: http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/versions/
-        </p>
-
-        <p>Sample result:</p>
-
-        <pre>
-        {
-            "serviceVersion": {
-                "version": "x.x.x"
-            },
-            "endpointVersions": {
-                "semanticsVersion": "x.x.x",
-            }
-        }</pre>
-
-        <hr>
-
-        <h2>
-            <a id="testing" class="anchor" href="#testing" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Testing
-        </h2>
-
-        <p>You can use command-line tools like <a href="https://en.wikipedia.org/wiki/CURL">curl</a> or some plugin for your favorite browser. For example:</p>
-
-        <ul>
-            <li>
-                <a href="https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop">Postman</a> for Chromium-based browsers
-            </li>
-            <li>
-                <a href="https://addons.mozilla.org/en-US/firefox/addon/httprequester/">HttpRequester</a> for Firefox
-            </li>
-        </ul>
-
-        <h3>
-            <a id="a-few-examples-with-curl" class="anchor" href="#a-few-examples-with-curl" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>A few examples with <code>curl</code>:
-        </h3>
-
-        <p><strong>One message:</strong></p>
-        <pre><code>$ curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' http://localhost:8080/publish/producer/msg?mp=eiffelsemantics</code></pre>
-
-        <p>Gives:</p>
-        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
-
-        <p><strong>Two messages/objects and given user domain suffix:</strong></p>
-        <pre><code>$ curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]},{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872dek89","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440998,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' http://localhost:8080/publish/producer/msg?ud=fem001&mp=eiffelsemantics</code></pre>
-
-        <p>Gives:</p>
-        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"},{"id":"963da060-f2cf-4370-a68d-67fd872dek89","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
-
-        <p><strong>One message and given tag:</strong></p>
-        <pre><code>$ curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' http://localhost:8080/publish/producer/msg?mp=eiffelsemantics&tag=production</code></pre>
-
-        <p>Gives:</p>
-        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
-
-        <p><strong>One message and given routing key:</strong></p>
-        <pre><code>$ curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' http://localhost:8080/publish/producer/msg?mp=eiffelsemantics&rk=myroutingkey</code></pre>
-
-        <p>Gives:</p>
-        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
-
-        <p><strong>NOTE:</strong> for any protocol, provide the Java opts as: </p>
-        <pre>set JAVA_OPTS="-Djava.ext.dirs=/path/to/jars/" in catalina.sh</pre>
-        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
-
-        <p><strong>Reading data from a file:</strong></p>
-        <pre><code>$ echo '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}, {"meta":{"id":"963da060-f2cf-4370-a68d-67fd872dek89","type":"EiffelActivityFinishedEvent","version":"1.0.0","time":1513758440998,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' > test.data
-            $ curl -H "Content-Type: application/json" -X POST --data-binary "@test.data" http://localhost:8080/publish/producer/msg?mp=eiffelsemantics
-        </code></pre>
-
-        <p>Gives:</p>
-        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"},{"id":"963da060-f2cf-4370-a68d-67fd872dek89","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
-
-        <p><strong>Malformed input:</strong></p>
-        <pre><code>$ curl -H "Content-Type: application/json" -X POST -d '[{Message}]' http://localhost:8080/publish/producer/msg?ud=fem001&mp=eiffel3</code></pre>
-
-        <p>Gives:</p>
-        <pre>{"timestamp":"Dec 27, 2017 3:34:11 PM","status":400,"error":"Bad Request","exception":"org.springframework.http.converter.HttpMessageNotReadableException","message":"Could not read JSON: ..."}</pre>
-
-        <h2>
-            <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Status Codes
-        </h2>
-
-        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.
-            Status codes are generated according to the below tables.
-        </p>
-        <p><strong>NOTE:</strong> we have a status code on the HTTP response and an internal status code.</p>
-
-        <p><strong>HTTP response codes:</strong></p>
-        <table class="wikitable">
-            <tr>
-                <th style="text-align:left;">Status code</th>
-                <th style="text-align:left;">HTTP response</th>
-                <th style="text-align:left;">Comment</th>
-            </tr>
-            <tr>
-                <td>200</td>
-                <td>OK</td>
-                <td>Status code of 200 is returned if the event is published successfully.</td>
-            </tr>
-            <tr>
-                <td>207</td>
-                <td>Multi Status</td>
-                <td>Status code of 207 is returned if we have a mix of internal status codes, i.e. Publish of few events was successful and few
-                    events was a failure. It is only applicable for batch publishing.<br>
-                    Incase of Multiple events in the body JSON, if a event is given internal status code of 400 or 500 rest events will not be
-                    published and will be given a internal status code of 503, which will result in overall HTTP response code of 207.
-                </td>
-            </tr>
-            <tr>
-                <td>400</td>
-                <td>Bad Request</td>
-                <td> Status code of 400 is returned if the request body JSON is malformed. i.e. Unable to parse the body JSON. This status code is
-                    applicable if request body JSON is a single event or multiple events.
-                </td>
-            </tr>
-            <tr>
-                <td>404</td>
-                <td>Not Found</td>
-                <td>Status code of 404 is returned if RabbitMQ message broker properties are not found for the requested protocol. This status
-                        code is applicable if request body JSON is a single event or multiple events.
-                </td>
-            </tr>
-            <tr>
-                <td>500</td>
-                <td>Internal Server Error</td>
-                <td>Status code of 500 is returned if RabbitMQ is down or could not prepare routing key to publish the eiffel event. This status
-                    code is applicable if request body JSON is a single event.
-                </td>
-            </tr>
-        </table>
-
-        <p><strong>Internal status codes:</strong></p>
-        <table class="wikitable">
-            <tr>
-                <th style="text-align:left;">Status code</th>
-                <th style="text-align:left;">Result</th>
-                <th style="text-align:left;">Message</th>
-                <th style="text-align:left;">Comment</th>
-            </tr>
-            <tr>
-                <td>200</td>
-                <td>SUCCESS</td>
-                <td>Event sent successfully</td>
-                <td>Status code of 200 is returned if the request is completed successfully.</td>
-            </tr>
-            <tr>
-                <td>400</td>
-                <td>Bad Request</td>
-                <td>Invalid event content, client need to fix problem in event before submitting again</td>
-                <td>Status code of 400 is returned if the request body JSON is malformed. i.e. Unable to parse the body JSON.
-                    Applicable to single and multiple events in JSON (or) an event has a missing ID field.
-                </td>
-            </tr>
-            <tr>
-                <td>404</td>
-                <td>RabbitMQ properties not found</td>
-                <td>RabbitMQ properties not configured for the protocol &lt;protocol&gt;</td>
-                <td>Status code of 404 is returned if RabbitMQ message broker properties are not found for the event.</td>
-            </tr>
-            <tr>
-                <td rowspan="2">500</td>
-                <td rowspan="2">Internal Server Error</td>
-                <td>RabbitMQ is down. Please try later</td>
-                <td>Status code of 500 is returned if RabbitMQ is down.</td>
-            </tr>
-            <tr>
-                <td>Could not prepare Routing key to publish message.</td>
-                <td>Status code of 500 is returned if could not prepare routing key to publish the eiffel event.</td>
-            </tr>
-            <tr>
-                <td>503</td>
-                <td>Service Unavailable</td>
-                <td>Please check previous event and try again later</td>
-                <td>Status code of 503 is returned if there is a failure in publishing previous event with 400, 404 or 500 error.</td>
-            </tr>
-        </table>
-
-        <p><strong>Status Codes explanation:</strong></p>
-
-        <p><strong>200:</strong> when all the events are sent successfully, then the internal status code for each event and status code for HTTP
-                response will be 200.
-        </p>
-        <pre><code><strong>HTTP Response:</strong> 200 :OK
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                }
-            ]</code></pre>
-
-        <p><strong>400:</strong> when the input JSON is malformated, that particular events internal status code will be 400.</p>
-        <pre><code><strong>HTTP Response:</strong> 400 :Bad Request
-            [
-                {
-                 "status_code":400,
-                 "result":"Bad Request",
-                 "message":"Invalid event content, client need to fix problem in event before submitting again"
-                }
-            ]</code></pre>
-
-        <p><strong>207:</strong> when the events are having different internal status codes, then the status code of HTTP response will be 207.</p>
-        <pre><code><strong>HTTP Response:</strong> 207 :Multi Status
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "status_code":400,
-                 "result":"Bad Request",
-                 "message":"Invalid event content, client need to fix problem in event before submitting again"
-                }
-            ]</code></pre>
-
-        <p><strong>500:</strong> we will get this status code, when the event is failed to send because of internal server error.</p>
-        <pre><code><strong>HTTP Response:</strong> 500 :Internal Server Error
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":500,
-                 "result":"Internal Server Error",
-                 "message":"RabbitMQ is down. Please try later"
-                }
-            ]</code></pre>
-
-        <p><strong>503:</strong> event will have this status code when the previous event is failed to send.</p>
-        <p>For example, consider you have 5 events.<br>
-            E1<-E2<-E3<-E4<-E5<br>
-            You send them all to publish in a batch command.<br>
-            E1 and E2 is successful. (200)<br>
-            E3 is malformatted. (400)<br>
-            If we send E4 and E5 we will have a broken chain so that is not a good option. In this case we should skip sending E4 and E5 and have status code 503 for those.
-        </p>
-        <pre><code><Strong>HTTP Response</strong>: 207 :Multi Status
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "status_code":400,
-                 "result":"Bad Request",
-                 "message":"Invalid event content, client need to fix problem in event before submitting again"
-                },
-                {
-                 "status_code":503,
-                 "result":"Service Unavailable",
-                 "message":"Please check previous event and try again later"
-                },
-                {
-                 "status_code":503,
-                 "result":"Service Unavailable",
-                 "message":"Please check previous event and try again later"
-                }
-            ]</code></pre>
-
-        <p><strong>404:</strong> we will get this status code, when RabbitMQ properties not configured in tomcat/conf/config.properties file for the protocol.</p>
-        <pre><code><strong>HTTP Response:</strong> 404 :Not Found
-            [
-                {
-                "status_code": 404,
-                "result": "RabbitMQ properties not found",
-                "message": "RabbitMQ properties not configured for the protocol &lt;protocol&gt;"
-                }
-            ]</code></pre>
-
-        <p><strong>500:</strong> we will get this status code, when cannot prepare routing key.</p>
-        <pre><code><strong>HTTP Response:</strong> 500 :Internal Server Error
-            [
-                {
-                "status_code": 500,
-                "result": "Internal Server Error",
-                "message": "Could not prepare Routing key to publish message"
-                }
-            ]</code></pre>
-
-        <p>You can open the RabbitMQ's management console and find these messages in a queue.</p>
 
         <h2>Logging</h2>
-
         <p>REMReM Publish application logging is implemented using the logback-classic. It requires user to configure the logback.xml file.<br>
-            When used without logback.xml log messages will look as below:</p>
+            When used without logback.xml log messages will look as below:
+        </p>
 
         <pre><code>%PARSER_ERROR[wEx]%PARSER_ERROR[clr] %PARSER_ERROR[clr] %PARSER_ERROR[clr] %PARSER_ERROR[clr]
             <br>%PARSER_ERROR[clr] %PARSER_ERROR[clr] %PARSER_ERROR[clr]</code></pre>
 
         <p>To configure the logback.xml file use <strong>-Dlogging.config=path/logback.xml</strong></p>
-
-        <p><a href="https://logback.qos.ch/manual/configuration.html">Click here</a> for info about logback configurations</p>
-
-        <p>To get sample logback.xml to use <a target="_blank" href="logback/logback-sample.xml">Click Here</a></p>
+        <p>To get info about logback configurations see <a href="https://logback.qos.ch/manual/configuration.html">here</a>.</p>
+        <p>To get sample logback.xml to use see <a target="_blank" href="logback/logback-sample.xml">here</a>.</p>
 
     </section>
 </div>
@@ -691,7 +144,7 @@ activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;
 <!-- FOOTER  -->
 <div id="footer_wrap" class="outer">
     <footer class="inner">
-        <p class="copyright">Eiffel REMReM Publish maintained by <a href="https://github.com/evasiba-ericsson">evasiba-ericsson</a></p>
+        <p class="copyright">Eiffel REMReM Publish maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
         <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
     </footer>
 </div>

--- a/javascripts/download.js
+++ b/javascripts/download.js
@@ -1,0 +1,29 @@
+function getLatestVersion(type,extn) {
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", "https://jitpack.io/v/Ericsson/eiffel-remrem-publish.svg");
+    xhr.responseType = "blob";//force the HTTP response, response-type header to be blob
+    xhr.onload = function() {
+        var blob = xhr.response;
+        var reader = new FileReader();
+        reader.addEventListener("loadend", function() {
+            var result = reader.result;
+            if(result=="Repo not found or no access token provided"){
+                document.getElementById("downloadLink").innerHTML = result;
+                document.getElementById("downloadLink").style.visibility = "";
+            } else {
+                document.getElementById("downloadLink").innerHTML = result;
+                var val = document.getElementsByTagName("text")[2].innerHTML;
+                val = val.trim();
+                urlLink = "https://jitpack.io/com/github/Ericsson/eiffel-remrem-publish/publish-"+type +"/"+val+"/publish-"+type +"-"+val+"."+extn;
+                var link = document.createElement("a");
+                link.setAttribute('id',"MYLINK");
+                link.href = urlLink;
+                document.body.appendChild(link);
+                link.setAttribute("type", "hidden");
+                link.click();
+            }
+        });
+        reader.readAsBinaryString(blob);
+    }
+    xhr.send();
+}

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -129,7 +129,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                 <th width="20%">Description</th>
             </tr>
             <tr>
-                <td>/generateAndPublish</td>
+                <td>/producer/msg</td>
                 <td>POST</td>
                 <td>
                     <p>mp - message protocol, required</p>
@@ -154,7 +154,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                 <td>This endpoint is used to publish already generated Eiffel event to message bus.</td>
             </tr>
             <tr>
-                <td>/eiffelsemantics</td>
+                <td>/generateAndPublish</td>
                 <td>POST</td>
                 <td>
                     <p>mp - message protocol, required</p>

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -18,7 +18,7 @@
     <header class="inner">
         <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
 
-        <h1><a class="project_title" href="index.html#project_title"></a>Eiffel REMReM Publish</h1>
+        <h1><a class="project_title" href="index.html">Eiffel REMReM Publish</a></h1>
 
         <section id="downloads">
             <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
@@ -59,7 +59,7 @@
 
         <p><strong>NOTE:</strong> in each example assuming the publish-service.war is deployed in tomcat as <strong>publish</strong>.</p>
 
-        <h3>Exchange configurations:</h3>
+        <h3>Exchange configurations</h3>
 
         <p>These parameters are related to RabbitMQ Server, which will be used for publishing events:</p>
 
@@ -80,7 +80,7 @@
 
         <p><strong>NOTE:</strong> properties above should be configured for each protocol, that users are going to use.</p>
 
-        <h3>Ldap authentication configurations:</h3>
+        <h3>Ldap authentication configurations</h3>
 
         <p>Active Directory authentication can be enabled for the REMReM Publish Service by setting the configuration property
             <code>activedirectory.publish.enabled=true</code>.
@@ -127,8 +127,8 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                 <th>Resource</th>
                 <th>Method</th>
                 <th>Parameters</th>
-                <th>Request body</th>
-                <th>Description</th>
+                <th style="margin:0px;">Request body</th>
+                <th width="20%">Description</th>
             </tr>
             <tr>
                 <td>/generateAndPublish</td>
@@ -140,7 +140,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                     <p>tag - not required</p>
                     <p>rk - routing key, not required</p>
                 </td>
-                <td style="margin:0px;">
+                <td>
 <pre>{
   "meta": {
     # Matches the meta object
@@ -153,7 +153,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
   }
 }</pre>
                 </td>
-                <td width="20%">This endpoint is used to publish already generated Eiffel event to message bus.</td>
+                <td>This endpoint is used to publish already generated Eiffel event to message bus.</td>
             </tr>
             <tr>
                 <td>/eiffelsemantics</td>
@@ -164,7 +164,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                     <p>tag - not required</p>
                     <p>rk - routing key, not required</p>
                 </td>
-                <td style="margin:0px;">
+                <td>
 <pre>{
   "msgParams": {
     "meta": {
@@ -181,7 +181,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
   }
 }</pre>
                 </td>
-                <td width="20%">
+                <td>
                     <p>This endpoint is used to generate and publish Eiffel events to message bus.
                         It provides single endpoint for both REMReM Generate and REMReM Publish.</p>
                     <p>The service works on the relative link <code>/generateAndPublish</code> if run as standalone application or
@@ -192,8 +192,8 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                 <td>/versions</td>
                 <td>GET</td>
                 <td></td>
-                <td style="margin:0px;"></td>
-                <td width="20%">This endpoint is used to get versions of publish service and all loaded  protocols.</td>
+                <td></td>
+                <td>This endpoint is used to get versions of publish service and all loaded  protocols.</td>
             </tr>
         </table>
 
@@ -217,7 +217,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
         <h3>
             <a id="examples1" class="anchor" href="#examples1" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Examples for <code>/producer/msg</code> endpoint:
+            </a>Examples for <code>/producer/msg</code> endpoint
         </h3>
 
         <h5>One message:</h5>
@@ -257,7 +257,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
         <h3>
             <a id="examples2" class="anchor" href="#examples2" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Examples for <code>/generateAndPublish</code> endpoint:
+            </a>Examples for <code>/generateAndPublish</code> endpoint
         </h3>
 
         <h5>Correct message:</h5>
@@ -278,7 +278,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
         <h3>
             <a id="examples3" class="anchor" href="#examples3" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>Examples for <code>/versions</code> endpoint:
+            </a>Examples for <code>/versions</code> endpoint
         </h3>
         <pre><code>curl -H "Content-Type: application/json" -X GET http://localhost:8080/generate/versions</code></pre>
         <p>Result:</p>
@@ -290,219 +290,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
             </a>Status Codes
         </h2>
 
-        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.
-            Status codes are generated according to the below tables.
-        </p>
-        <p><strong>NOTE:</strong> we have a status code on the HTTP response and an internal status code.</p>
-
-        <p><strong>HTTP response codes:</strong></p>
-        <table class="wikitable">
-            <tr>
-                <th style="text-align:left;">Status code</th>
-                <th style="text-align:left;">HTTP response</th>
-                <th style="text-align:left;">Comment</th>
-            </tr>
-            <tr>
-                <td>200</td>
-                <td>OK</td>
-                <td>Status code of 200 is returned if the event is published successfully.</td>
-            </tr>
-            <tr>
-                <td>207</td>
-                <td>Multi Status</td>
-                <td>Status code of 207 is returned if we have a mix of internal status codes, i.e. Publish of few events was successful and few
-                    events was a failure. It is only applicable for batch publishing.<br>
-                    Incase of Multiple events in the body JSON, if a event is given internal status code of 400 or 500 rest events will not be
-                    published and will be given a internal status code of 503, which will result in overall HTTP response code of 207.
-                </td>
-            </tr>
-            <tr>
-                <td>400</td>
-                <td>Bad Request</td>
-                <td> Status code of 400 is returned if the request body JSON is malformed. i.e. Unable to parse the body JSON. This status code is
-                    applicable if request body JSON is a single event or multiple events.
-                </td>
-            </tr>
-            <tr>
-                <td>404</td>
-                <td>Not Found</td>
-                <td>Status code of 404 is returned if RabbitMQ message broker properties are not found for the requested protocol. This status
-                        code is applicable if request body JSON is a single event or multiple events.
-                </td>
-            </tr>
-            <tr>
-                <td>500</td>
-                <td>Internal Server Error</td>
-                <td>Status code of 500 is returned if RabbitMQ is down or could not prepare routing key to publish the eiffel event. This status
-                    code is applicable if request body JSON is a single event.
-                </td>
-            </tr>
-        </table>
-
-        <p><strong>Internal status codes:</strong></p>
-        <table class="wikitable">
-            <tr>
-                <th style="text-align:left;">Status code</th>
-                <th style="text-align:left;">Result</th>
-                <th style="text-align:left;">Message</th>
-                <th style="text-align:left;">Comment</th>
-            </tr>
-            <tr>
-                <td>200</td>
-                <td>SUCCESS</td>
-                <td>Event sent successfully</td>
-                <td>Status code of 200 is returned if the request is completed successfully.</td>
-            </tr>
-            <tr>
-                <td>400</td>
-                <td>Bad Request</td>
-                <td>Invalid event content, client need to fix problem in event before submitting again</td>
-                <td>Status code of 400 is returned if the request body JSON is malformed. i.e. Unable to parse the body JSON.
-                    Applicable to single and multiple events in JSON (or) an event has a missing ID field.
-                </td>
-            </tr>
-            <tr>
-                <td>404</td>
-                <td>RabbitMQ properties not found</td>
-                <td>RabbitMQ properties not configured for the protocol &lt;protocol&gt;</td>
-                <td>Status code of 404 is returned if RabbitMQ message broker properties are not found for the event.</td>
-            </tr>
-            <tr>
-                <td rowspan="2">500</td>
-                <td rowspan="2">Internal Server Error</td>
-                <td>RabbitMQ is down. Please try later</td>
-                <td>Status code of 500 is returned if RabbitMQ is down.</td>
-            </tr>
-            <tr>
-                <td>Could not prepare Routing key to publish message.</td>
-                <td>Status code of 500 is returned if could not prepare routing key to publish the eiffel event.</td>
-            </tr>
-            <tr>
-                <td>503</td>
-                <td>Service Unavailable</td>
-                <td>Please check previous event and try again later</td>
-                <td>Status code of 503 is returned if there is a failure in publishing previous event with 400, 404 or 500 error.</td>
-            </tr>
-        </table>
-
-        <p><strong>Status Codes explanation:</strong></p>
-
-        <p><strong>200:</strong> when all the events are sent successfully, then the internal status code for each event and status code for HTTP
-                response will be 200.
-        </p>
-        <pre><code><strong>HTTP Response:</strong> 200 :OK
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                }
-            ]</code></pre>
-
-        <p><strong>400:</strong> when the input JSON is malformated, that particular events internal status code will be 400.</p>
-        <pre><code><strong>HTTP Response:</strong> 400 :Bad Request
-            [
-                {
-                 "status_code":400,
-                 "result":"Bad Request",
-                 "message":"Invalid event content, client need to fix problem in event before submitting again"
-                }
-            ]</code></pre>
-
-        <p><strong>207:</strong> when the events are having different internal status codes, then the status code of HTTP response will be 207.</p>
-        <pre><code><strong>HTTP Response:</strong> 207 :Multi Status
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "status_code":400,
-                 "result":"Bad Request",
-                 "message":"Invalid event content, client need to fix problem in event before submitting again"
-                }
-            ]</code></pre>
-
-        <p><strong>500:</strong> we will get this status code, when the event is failed to send because of internal server error.</p>
-        <pre><code><strong>HTTP Response:</strong> 500 :Internal Server Error
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":500,
-                 "result":"Internal Server Error",
-                 "message":"RabbitMQ is down. Please try later"
-                }
-            ]</code></pre>
-
-        <p><strong>503:</strong> event will have this status code when the previous event is failed to send.</p>
-        <p>For example, consider you have 5 events.<br>
-            E1<-E2<-E3<-E4<-E5<br>
-            You send them all to publish in a batch command.<br>
-            E1 and E2 is successful. (200)<br>
-            E3 is malformatted. (400)<br>
-            If we send E4 and E5 we will have a broken chain so that is not a good option. In this case we should skip sending E4 and E5 and have status code 503 for those.
-        </p>
-        <pre><code><Strong>HTTP Response</strong>: 207 :Multi Status
-            [
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
-                 "status_code":200,
-                 "result":"SUCCESS",
-                 "message":"Event sent successfully"
-                },
-                {
-                 "status_code":400,
-                 "result":"Bad Request",
-                 "message":"Invalid event content, client need to fix problem in event before submitting again"
-                },
-                {
-                 "status_code":503,
-                 "result":"Service Unavailable",
-                 "message":"Please check previous event and try again later"
-                },
-                {
-                 "status_code":503,
-                 "result":"Service Unavailable",
-                 "message":"Please check previous event and try again later"
-                }
-            ]</code></pre>
-
-        <p><strong>404:</strong> we will get this status code, when RabbitMQ properties not configured in tomcat/conf/config.properties file for the protocol.</p>
-        <pre><code><strong>HTTP Response:</strong> 404 :Not Found
-            [
-                {
-                "status_code": 404,
-                "result": "RabbitMQ properties not found",
-                "message": "RabbitMQ properties not configured for the protocol &lt;protocol&gt;"
-                }
-            ]</code></pre>
-
-        <p><strong>500:</strong> we will get this status code, when cannot prepare routing key.</p>
-        <pre><code><strong>HTTP Response:</strong> 500 :Internal Server Error
-            [
-                {
-                "status_code": 500,
-                "result": "Internal Server Error",
-                "message": "Could not prepare Routing key to publish message"
-                }
-            ]</code></pre>
-
-        <p>You can open the RabbitMQ's management console and find these messages in a queue.</p>
+        <p>To get information about internal status codes see <a href="statusCodes.html">here</a>.</p>
 
     </section>
 </div>

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -119,8 +119,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Usage
         </h2>
-
-        <p>The request body must contain a <strong>JSON Object or JSON Array</strong> with the messages.</p>
+        <p>Available REST resources for REMReM Generate Service are described below.</p>
 
         <table style="width:100%">
             <tr>
@@ -202,6 +201,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Examples
         </h2>
+        <p>Typical examples of usage Eiffel REMReM Publish Service endpoints are described below.</p>
 
         <p>You can use command line tools like <a href="https://en.wikipedia.org/wiki/CURL">curl</a> or some plugin for your favorite browser. For example:</p>
 

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -290,6 +290,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
             </a>Status Codes
         </h2>
 
+        <p>For each user request Eiffel REMReM Publish generate response in JSON with internal status code and message.</p>
         <p>To get information about internal status codes see <a href="statusCodes.html">here</a>.</p>
 
     </section>

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -1,0 +1,519 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="description" content="Eiffel RemRem Publish Service : ">
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+
+    <title>Eiffel REMReM Publish</title>
+</head>
+
+<body>
+
+<!-- HEADER -->
+<div id="header_wrap" class="outer">
+    <header class="inner">
+        <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
+
+        <h1><a class="project_title" href="index.html#project_title"></a>Eiffel REMReM Publish</h1>
+
+        <section id="downloads">
+            <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
+            <a class="tar_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/tarball/master">Download this project as a tar.gz file</a>
+        </section>
+    </header>
+</div>
+
+<!-- MAIN CONTENT -->
+<div id="main_content_wrap" class="outer">
+    <section id="main_content" class="inner">
+
+        <h1>
+            <a id="remrem-publish-service" class="anchor" href="#remrem-publish-service" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>REMReM Publish Service
+        </h1>
+
+        <p>REMReM Publish Service allows for sending messages to a topic-based exchange on a RabbitMQ Server.</p>
+
+        <p>Information about the REMReM Publish Service all endpoints can be got and easily accessed using next links:</p>
+        <pre>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/</pre> or <pre>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/swagger-ui.html</pre>
+
+        <p>Example:</p>
+        <pre>http://localhost:8080/publish/</pre>
+
+        <h2>
+            <a id="configuration" class="anchor" href="#configuration" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Configuration
+        </h2>
+
+        <p>For using Eiffel REMReM Service <strong>publish-service.war</strong> file should be deployed in Tomcat Server.
+            For doing this, publish-service.war file should locate in next directory: <em>tomcat/webapps</em>.
+        </p>
+
+        <p>Configuration is done in Tomcat using a config.properties file: <em>tomcat/conf/config.properties</em>.</p>
+
+        <p><strong>NOTE:</strong> in each example assuming the publish-service.war is deployed in tomcat as <strong>publish</strong>.</p>
+
+        <h3>Exchange configurations:</h3>
+
+        <p>These parameters are related to RabbitMQ Server, which will be used for publishing events:</p>
+
+        <pre>
+&lt;protocol&gt;.rabbitmq.host:          &lt;host name, eg: localhost&gt;
+&lt;protocol&gt;.rabbitmq.port:          &lt;port, eg: 5672&gt;
+&lt;protocol&gt;.rabbitmq.username:      &lt;username, default for RabbitMQ Server: guest&gt;
+&lt;protocol&gt;.rabbitmq.password:      &lt;password, default for RabbitMQ Server: guest&gt;
+&lt;protocol&gt;.rabbitmq.tls:           &lt;tls, is optional&gt;
+&lt;protocol&gt;.rabbitmq.exchangeName:  &lt;exchange name, exchange should be already created on RabbitMQ Server&gt;
+&lt;protocol&gt;.rabbitmq.domainId:      &lt;domain id, any string&gt;</pre>
+
+        <p>An <a href="https://www.rabbitmq.com/tutorials/tutorial-three-java.html">exchange point</a> must exist before starting the service.</p>
+
+        <p><code>&lt;protocol&gt;</code> is name of the protocol used.
+            For now two protocols are used: <code>eiffel3</code> (for Eiffel1.0 events) and <code>eiffelsemantics</code> (for Eiffel2.0 events).
+        </p>
+
+        <p><strong>NOTE:</strong> properties above should be configured for each protocol, that users are going to use.</p>
+
+        <h3>Ldap authentication configurations:</h3>
+
+        <p>Active Directory authentication can be enabled for the REMReM Publish Service by setting the configuration property
+            <code>activedirectory.publish.enabled=true</code>.
+        </p>
+
+        <pre>
+activedirectory.publish.enabled:  &lt;true|false&gt;
+activedirectory.ldapUrl:          &lt;LDAP server url&gt;
+activedirectory.managerPassword:  &lt;LDAP server manager password(must be base64 Encrypted format)&gt;
+activedirectory.managerDn:        &lt;LDAP managerDn pattern&gt;
+activedirectory.rootDn:           &lt;LDAP rootDn pattern&gt;
+activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;</pre>
+
+        <p><strong>LDAP authentication without Base64 encryption:</strong></p>
+        <pre><code>curl -XPOST -H "Content-Type: application/json" --user username:password --data @ActivityCanceled.json "http://localhost:8080/publish/producer/msg?mp=eiffelsemantics"</code></pre>
+
+        <p><strong>NOTE:</strong> each HTTP request must then include an Authorization header with value
+            <code>Basic &lt;Base64 encoded username:password&gt;</code>.
+        </p>
+
+        <p><strong>LDAP authentication with Base64 encryption:</strong></p>
+        <pre><code>curl -XPOST -H "Content-Type: application/json" -H 'Authorization: Basic cGFzc3dvcmQ=' --data @ActivityCanceled.json "http://localhost:8080/publish/producer/msg?mp=eiffelsemantics"</code></pre>
+
+        <h3>Generate Service configurations for Publish Service</h3>
+
+        <p>Properties below are important for correct work of <strong>/generateAndPublish</strong> endpoint.</p>
+
+        <pre>
+generate.server.host:    &lt;host, where generate service is deployed, eg: localhost&gt;
+generate.server.port:    &lt;port, eg: 8080&gt;
+generate.server.appName: &lt;application name of generate service, eg: generate&gt;</pre>
+
+
+        <h2>
+            <a id="usage" class="anchor" href="#usage" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Usage
+        </h2>
+
+        <p>The request body must contain a <strong>JSON Object or JSON Array</strong> with the messages.</p>
+
+        <table style="width:100%">
+            <tr>
+                <th>Resource</th>
+                <th>Method</th>
+                <th>Parameters</th>
+                <th>Request body</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td>/generateAndPublish</td>
+                <td>POST</td>
+                <td>
+                    <p>mp - message protocol, required</p>
+                    <p>msgType - message type, required</p>
+                    <p>ud - user domain, not required</p>
+                    <p>tag - not required</p>
+                    <p>rk - routing key, not required</p>
+                </td>
+                <td style="margin:0px;">
+<pre>{
+  "meta": {
+    # Matches the meta object
+  },
+  "data": {
+    # Matches the data object
+  },
+  "links": {
+    # Matches the links object
+  }
+}</pre>
+                </td>
+                <td width="20%">This endpoint is used to publish already generated Eiffel event to message bus.</td>
+            </tr>
+            <tr>
+                <td>/eiffelsemantics</td>
+                <td>POST</td>
+                <td>
+                    <p>mp - message protocol, required</p>
+                    <p>ud - user domain, not required</p>
+                    <p>tag - not required</p>
+                    <p>rk - routing key, not required</p>
+                </td>
+                <td style="margin:0px;">
+<pre>{
+  "msgParams": {
+    "meta": {
+      # Matches the meta object
+    }
+  },
+  "eventParams": {
+    "data": {
+      # Matches the data object
+    },
+    "links": {
+      # Matches the links object
+    }
+  }
+}</pre>
+                </td>
+                <td width="20%">
+                    <p>This endpoint is used to generate and publish Eiffel events to message bus.
+                        It provides single endpoint for both REMReM Generate and REMReM Publish.</p>
+                    <p>The service works on the relative link <code>/generateAndPublish</code> if run as standalone application or
+                        <code>/publish/generateAndPublish</code> if run as tomcat app.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>/versions</td>
+                <td>GET</td>
+                <td></td>
+                <td style="margin:0px;"></td>
+                <td width="20%">This endpoint is used to get versions of publish service and all loaded  protocols.</td>
+            </tr>
+        </table>
+
+        <h2>
+            <a id="examples" class="anchor" href="#examples" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples
+        </h2>
+
+        <p>You can use command line tools like <a href="https://en.wikipedia.org/wiki/CURL">curl</a> or some plugin for your favorite browser. For example:</p>
+
+        <ul>
+            <li>
+                <a href="https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop">Postman</a> for Chromium-based browsers
+            </li>
+            <li>
+                <a href="https://addons.mozilla.org/en-US/firefox/addon/httprequester/">HttpRequester</a> for Firefox
+            </li>
+        </ul>
+
+        <h3>
+            <a id="examples1" class="anchor" href="#examples1" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/producer/msg</code> endpoint:
+        </h3>
+
+        <h5>One message:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' "http://localhost:8080/publish/producer/msg?mp=eiffelsemantics"</code></pre>
+        <p>Result:</p>
+        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
+
+        <h5>Two messages/objects and given user domain suffix:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]},{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872dek89","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1513758440998,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' "http://localhost:8080/publish/producer/msg?ud=fem001&mp=eiffelsemantics"</code></pre>
+        <p>Result:</p>
+        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"},{"id":"963da060-f2cf-4370-a68d-67fd872dek89","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
+
+        <h5>One message and given tag:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' "http://localhost:8080/publish/producer/msg?mp=eiffelsemantics&tag=production"</code></pre>
+        <p>Result:</p>
+        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
+
+        <h5>One message and given routing key:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{"meta":{"id":"963da060-f2cf-4370-a68d-67fd872def36","type":"EiffelActivityFinishedEvent","version":"1.1.0","time":1513758440588,"tags":["tag1","tag2"],"source":{"domainId":"example.domain","host":"host","name":"name","serializer":{"groupId":"com.github.Ericsson","artifactId":"eiffel-remrem-semantics","version":"0.3.1"},"uri":"http://java.sun.com/j2se/1.3/"},"security":{"sdm":{"authorIdentity":"test","encryptedDigest":"sample"}}},"data":{"outcome":{"conclusion":"SUCCESSFUL"},"persistentLogs":[{"name":"firstLog","uri":"http://myHost.com/firstLog"},{"name":"otherLog","uri":"isbn:0-486-27557-4"}],"customData":[]},"links":[{"type":"ACTIVITY_EXECUTION","target":"aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}]' "http://localhost:8080/publish/producer/msg?mp=eiffelsemantics&rk=myroutingkey"</code></pre>
+        <p>Result:</p>
+        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
+
+        <p><strong>NOTE:</strong> for any protocol, provide the Java opts as: </p>
+        <pre>set JAVA_OPTS="-Djava.ext.dirs=/path/to/jars/" in catalina.sh</pre>
+        <p><strong>NOTE:</strong> in the above example, protocol jar file must be present inside "/path/to/jars/" folder.</p>
+
+        <h5>Reading data from a file:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST --data-binary "@test.data" "http://localhost:8080/publish/producer/msg?mp=eiffelsemantics"</code></pre>
+        <p>Result:</p>
+        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"},{"id":"963da060-f2cf-4370-a68d-67fd872dek89","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
+
+        <h5>Malformed input:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{Message}]' "http://localhost:8080/publish/producer/msg?ud=fem001&mp=eiffel3"</code></pre>
+        <p>Result:</p>
+        <pre>{"timestamp":"Dec 27, 2017 3:34:11 PM","status":400,"error":"Bad Request","exception":"org.springframework.http.converter.HttpMessageNotReadableException","message":"Could not read JSON: ..."}</pre>
+
+        <h3>
+            <a id="examples2" class="anchor" href="#examples2" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/generateAndPublish</code> endpoint:
+        </h3>
+
+        <h5>Correct message:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '{"msgParams": {"meta": {"type": "EiffelActivityFinishedEvent", "tags": ["tag1","tag2"], "source": {"domainId": "example.domain", "host": "host", "name": "name", "uri": "http://java.sun.com/j2se/1.3/", "gav": {"groupId": "com.github.Ericsson", "artifactId": "eiffel-remrem-semantics", "version": "0.2.9"}}, "security": {"sdm": {"authorIdentity": "test", "encryptedDigest": "sample"}}}}, "eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"}, "persistentLogs": [{"name": "firstLog", "uri": "http://myHost.com/firstLog"}, {"name": "otherLog", "uri": "isbn:0-486-27557-4"}]}, "links": [{"type": "ACTIVITY_EXECUTION", "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}' "http://localhost:8080/publish/generateAndPublish?mp=eiffelsemantics&msgType=EiffelActivityFinished"</code></pre>
+        <p>Result:</p>
+        <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
+
+        <h5>Incorrect message protocol:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '{"msgParams": {"meta": {"type": "EiffelActivityFinishedEvent", "tags": ["tag1","tag2"], "source": {"domainId": "example.domain", "host": "host", "name": "name", "uri": "http://java.sun.com/j2se/1.3/", "gav": {"groupId": "com.github.Ericsson", "artifactId": "eiffel-remrem-semantics", "version": "0.2.9"}}, "security": {"sdm": {"authorIdentity": "test", "encryptedDigest": "sample"}}}}, "eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"}, "persistentLogs": [{"name": "firstLog", "uri": "http://myHost.com/firstLog"}, {"name": "otherLog", "uri": "isbn:0-486-27557-4"}]}, "links": [{"type": "ACTIVITY_EXECUTION", "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}' "http://localhost:8080/publish/generateAndPublish?mp=incorrecteiffelprotocol&msgType=EiffelActivityFinished"</code></pre>
+        <p>Result:</p>
+        <pre>{"status_code":503,"result":"FAIL","message":"Message protocol is invalid"}</pre>
+
+        <h5>Incorrect message type:</h5>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '{"msgParams": {"meta": {"type": "EiffelActivityFinishedEvent", "tags": ["tag1","tag2"], "source": {"domainId": "example.domain", "host": "host", "name": "name", "uri": "http://java.sun.com/j2se/1.3/", "gav": {"groupId": "com.github.Ericsson", "artifactId": "eiffel-remrem-semantics", "version": "0.2.9"}}, "security": {"sdm": {"authorIdentity": "test", "encryptedDigest": "sample"}}}}, "eventParams": {"data": {"outcome": {"conclusion": "SUCCESSFUL"}, "persistentLogs": [{"name": "firstLog", "uri": "http://myHost.com/firstLog"}, {"name": "otherLog", "uri": "isbn:0-486-27557-4"}]}, "links": [{"type": "ACTIVITY_EXECUTION", "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"}]}}' "http://localhost:8080/publish/generateAndPublish?mp=eiffelsemantics&msgType=incorrectmessagetype"</code></pre>
+        <p>Result:</p>
+        <pre>{"status_code":400,"result":"FAIL","message":"Malformed JSON or incorrect type of event"}</pre>
+
+        <h3>
+            <a id="examples3" class="anchor" href="#examples3" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Examples for <code>/versions</code> endpoint:
+        </h3>
+        <pre><code>curl -H "Content-Type: application/json" -X GET http://localhost:8080/generate/versions</code></pre>
+        <p>Result:</p>
+        <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x","eiffel3MessagingVersion":"x.x.x"}}</pre>
+
+        <h2>
+            <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Status Codes
+        </h2>
+
+        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.
+            Status codes are generated according to the below tables.
+        </p>
+        <p><strong>NOTE:</strong> we have a status code on the HTTP response and an internal status code.</p>
+
+        <p><strong>HTTP response codes:</strong></p>
+        <table class="wikitable">
+            <tr>
+                <th style="text-align:left;">Status code</th>
+                <th style="text-align:left;">HTTP response</th>
+                <th style="text-align:left;">Comment</th>
+            </tr>
+            <tr>
+                <td>200</td>
+                <td>OK</td>
+                <td>Status code of 200 is returned if the event is published successfully.</td>
+            </tr>
+            <tr>
+                <td>207</td>
+                <td>Multi Status</td>
+                <td>Status code of 207 is returned if we have a mix of internal status codes, i.e. Publish of few events was successful and few
+                    events was a failure. It is only applicable for batch publishing.<br>
+                    Incase of Multiple events in the body JSON, if a event is given internal status code of 400 or 500 rest events will not be
+                    published and will be given a internal status code of 503, which will result in overall HTTP response code of 207.
+                </td>
+            </tr>
+            <tr>
+                <td>400</td>
+                <td>Bad Request</td>
+                <td> Status code of 400 is returned if the request body JSON is malformed. i.e. Unable to parse the body JSON. This status code is
+                    applicable if request body JSON is a single event or multiple events.
+                </td>
+            </tr>
+            <tr>
+                <td>404</td>
+                <td>Not Found</td>
+                <td>Status code of 404 is returned if RabbitMQ message broker properties are not found for the requested protocol. This status
+                        code is applicable if request body JSON is a single event or multiple events.
+                </td>
+            </tr>
+            <tr>
+                <td>500</td>
+                <td>Internal Server Error</td>
+                <td>Status code of 500 is returned if RabbitMQ is down or could not prepare routing key to publish the eiffel event. This status
+                    code is applicable if request body JSON is a single event.
+                </td>
+            </tr>
+        </table>
+
+        <p><strong>Internal status codes:</strong></p>
+        <table class="wikitable">
+            <tr>
+                <th style="text-align:left;">Status code</th>
+                <th style="text-align:left;">Result</th>
+                <th style="text-align:left;">Message</th>
+                <th style="text-align:left;">Comment</th>
+            </tr>
+            <tr>
+                <td>200</td>
+                <td>SUCCESS</td>
+                <td>Event sent successfully</td>
+                <td>Status code of 200 is returned if the request is completed successfully.</td>
+            </tr>
+            <tr>
+                <td>400</td>
+                <td>Bad Request</td>
+                <td>Invalid event content, client need to fix problem in event before submitting again</td>
+                <td>Status code of 400 is returned if the request body JSON is malformed. i.e. Unable to parse the body JSON.
+                    Applicable to single and multiple events in JSON (or) an event has a missing ID field.
+                </td>
+            </tr>
+            <tr>
+                <td>404</td>
+                <td>RabbitMQ properties not found</td>
+                <td>RabbitMQ properties not configured for the protocol &lt;protocol&gt;</td>
+                <td>Status code of 404 is returned if RabbitMQ message broker properties are not found for the event.</td>
+            </tr>
+            <tr>
+                <td rowspan="2">500</td>
+                <td rowspan="2">Internal Server Error</td>
+                <td>RabbitMQ is down. Please try later</td>
+                <td>Status code of 500 is returned if RabbitMQ is down.</td>
+            </tr>
+            <tr>
+                <td>Could not prepare Routing key to publish message.</td>
+                <td>Status code of 500 is returned if could not prepare routing key to publish the eiffel event.</td>
+            </tr>
+            <tr>
+                <td>503</td>
+                <td>Service Unavailable</td>
+                <td>Please check previous event and try again later</td>
+                <td>Status code of 503 is returned if there is a failure in publishing previous event with 400, 404 or 500 error.</td>
+            </tr>
+        </table>
+
+        <p><strong>Status Codes explanation:</strong></p>
+
+        <p><strong>200:</strong> when all the events are sent successfully, then the internal status code for each event and status code for HTTP
+                response will be 200.
+        </p>
+        <pre><code><strong>HTTP Response:</strong> 200 :OK
+            [
+                {
+                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+                 "status_code":200,
+                 "result":"SUCCESS",
+                 "message":"Event sent successfully"
+                },
+                {
+                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
+                 "status_code":200,
+                 "result":"SUCCESS",
+                 "message":"Event sent successfully"
+                }
+            ]</code></pre>
+
+        <p><strong>400:</strong> when the input JSON is malformated, that particular events internal status code will be 400.</p>
+        <pre><code><strong>HTTP Response:</strong> 400 :Bad Request
+            [
+                {
+                 "status_code":400,
+                 "result":"Bad Request",
+                 "message":"Invalid event content, client need to fix problem in event before submitting again"
+                }
+            ]</code></pre>
+
+        <p><strong>207:</strong> when the events are having different internal status codes, then the status code of HTTP response will be 207.</p>
+        <pre><code><strong>HTTP Response:</strong> 207 :Multi Status
+            [
+                {
+                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+                 "status_code":200,
+                 "result":"SUCCESS",
+                 "message":"Event sent successfully"
+                },
+                {
+                 "status_code":400,
+                 "result":"Bad Request",
+                 "message":"Invalid event content, client need to fix problem in event before submitting again"
+                }
+            ]</code></pre>
+
+        <p><strong>500:</strong> we will get this status code, when the event is failed to send because of internal server error.</p>
+        <pre><code><strong>HTTP Response:</strong> 500 :Internal Server Error
+            [
+                {
+                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+                 "status_code":500,
+                 "result":"Internal Server Error",
+                 "message":"RabbitMQ is down. Please try later"
+                }
+            ]</code></pre>
+
+        <p><strong>503:</strong> event will have this status code when the previous event is failed to send.</p>
+        <p>For example, consider you have 5 events.<br>
+            E1<-E2<-E3<-E4<-E5<br>
+            You send them all to publish in a batch command.<br>
+            E1 and E2 is successful. (200)<br>
+            E3 is malformatted. (400)<br>
+            If we send E4 and E5 we will have a broken chain so that is not a good option. In this case we should skip sending E4 and E5 and have status code 503 for those.
+        </p>
+        <pre><code><Strong>HTTP Response</strong>: 207 :Multi Status
+            [
+                {
+                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+                 "status_code":200,
+                 "result":"SUCCESS",
+                 "message":"Event sent successfully"
+                },
+                {
+                 "id":"9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
+                 "status_code":200,
+                 "result":"SUCCESS",
+                 "message":"Event sent successfully"
+                },
+                {
+                 "status_code":400,
+                 "result":"Bad Request",
+                 "message":"Invalid event content, client need to fix problem in event before submitting again"
+                },
+                {
+                 "status_code":503,
+                 "result":"Service Unavailable",
+                 "message":"Please check previous event and try again later"
+                },
+                {
+                 "status_code":503,
+                 "result":"Service Unavailable",
+                 "message":"Please check previous event and try again later"
+                }
+            ]</code></pre>
+
+        <p><strong>404:</strong> we will get this status code, when RabbitMQ properties not configured in tomcat/conf/config.properties file for the protocol.</p>
+        <pre><code><strong>HTTP Response:</strong> 404 :Not Found
+            [
+                {
+                "status_code": 404,
+                "result": "RabbitMQ properties not found",
+                "message": "RabbitMQ properties not configured for the protocol &lt;protocol&gt;"
+                }
+            ]</code></pre>
+
+        <p><strong>500:</strong> we will get this status code, when cannot prepare routing key.</p>
+        <pre><code><strong>HTTP Response:</strong> 500 :Internal Server Error
+            [
+                {
+                "status_code": 500,
+                "result": "Internal Server Error",
+                "message": "Could not prepare Routing key to publish message"
+                }
+            ]</code></pre>
+
+        <p>You can open the RabbitMQ's management console and find these messages in a queue.</p>
+
+    </section>
+</div>
+
+<!-- FOOTER  -->
+<div id="footer_wrap" class="outer">
+    <footer class="inner">
+        <p class="copyright">Eiffel REMReM Publish maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -83,7 +83,7 @@
         <h3>Ldap authentication configurations</h3>
 
         <p>Active Directory authentication can be enabled for the REMReM Publish Service by setting the configuration property
-            <code>activedirectory.publish.enabled=true</code>.
+            <code>activedirectory.publish.enabled: true</code>.
         </p>
 
         <pre>
@@ -106,7 +106,7 @@ activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;</pre>
 
         <h3>Generate Service configurations for Publish Service</h3>
 
-        <p>Properties below are important for correct work of <strong>/generateAndPublish</strong> endpoint.</p>
+        <p>Properties below are important for correct work of <code>/generateAndPublish</code> endpoint.</p>
 
         <pre>
 generate.server.host:    &lt;host, where generate service is deployed, eg: localhost&gt;

--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -68,14 +68,13 @@
 &lt;protocol&gt;.rabbitmq.port:          &lt;port, eg: 5672&gt;
 &lt;protocol&gt;.rabbitmq.username:      &lt;username, default for RabbitMQ Server: guest&gt;
 &lt;protocol&gt;.rabbitmq.password:      &lt;password, default for RabbitMQ Server: guest&gt;
-&lt;protocol&gt;.rabbitmq.tls:           &lt;tls, is optional&gt;
+&lt;protocol&gt;.rabbitmq.tls:           &lt;tls version, is optional&gt;
 &lt;protocol&gt;.rabbitmq.exchangeName:  &lt;exchange name, exchange should be already created on RabbitMQ Server&gt;
 &lt;protocol&gt;.rabbitmq.domainId:      &lt;domain id, any string&gt;</pre>
 
         <p>An <a href="https://www.rabbitmq.com/tutorials/tutorial-three-java.html">exchange point</a> must exist before starting the service.</p>
 
-        <p><code>&lt;protocol&gt;</code> is name of the protocol used.
-            For now two protocols are used: <code>eiffel3</code> (for Eiffel1.0 events) and <code>eiffelsemantics</code> (for Eiffel2.0 events).
+        <p><code>&lt;protocol&gt;</code> is name of the protocol used (eg: <code>eiffelsemantics</code>).
         </p>
 
         <p><strong>NOTE:</strong> properties above should be configured for each protocol, that users are going to use.</p>
@@ -250,7 +249,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
         <pre>{"events":[{"id":"963da060-f2cf-4370-a68d-67fd872def36","status_code":200,"result":"SUCCESS","message":"Event sent successfully"},{"id":"963da060-f2cf-4370-a68d-67fd872dek89","status_code":200,"result":"SUCCESS","message":"Event sent successfully"}]}</pre>
 
         <h5>Malformed input:</h5>
-        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{Message}]' "http://localhost:8080/publish/producer/msg?ud=fem001&mp=eiffel3"</code></pre>
+        <pre><code>curl -H "Content-Type: application/json" -X POST -d '[{Message}]' "http://localhost:8080/publish/producer/msg?ud=fem001&mp=eiffelsemantics"</code></pre>
         <p>Result:</p>
         <pre>{"timestamp":"Dec 27, 2017 3:34:11 PM","status":400,"error":"Bad Request","exception":"org.springframework.http.converter.HttpMessageNotReadableException","message":"Could not read JSON: ..."}</pre>
 
@@ -282,7 +281,7 @@ generate.server.appName: &lt;application name of generate service, eg: generate&
         </h3>
         <pre><code>curl -H "Content-Type: application/json" -X GET http://localhost:8080/generate/versions</code></pre>
         <p>Result:</p>
-        <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x","eiffel3MessagingVersion":"x.x.x"}}</pre>
+        <pre>{"serviceVersion":{"version":"x.x.x"},"endpointVersions":{"semanticsVersion":"x.x.x"}}</pre>
 
         <h2>
             <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">

--- a/statusCodes.html
+++ b/statusCodes.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="description" content="Eiffel RemRem Publish Service : ">
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+
+    <title>Eiffel REMReM Publish</title>
+</head>
+
+<body>
+
+<!-- HEADER -->
+<div id="header_wrap" class="outer">
+    <header class="inner">
+        <a id="forkme_banner" href="https://github.com/Ericsson/eiffel-remrem-publish">View on GitHub</a>
+
+        <h1><a class="project_title" href="index.html">Eiffel REMReM Publish</a></h1>
+
+        <section id="downloads">
+            <a class="zip_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/zipball/master">Download this project as a .zip file</a>
+            <a class="tar_download_link" href="https://github.com/Ericsson/eiffel-remrem-publish/tarball/master">Download this project as a tar.gz file</a>
+        </section>
+    </header>
+</div>
+
+<!-- MAIN CONTENT -->
+<div id="main_content_wrap" class="outer">
+    <section id="main_content" class="inner">
+
+        <h1>
+            <a id="remrem-publish-service" class="anchor" href="#remrem-publish-service" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>REMReM Publish Service
+        </h1>
+
+        <h2>
+            <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">
+                <span aria-hidden="true" class="octicon octicon-link"></span>
+            </a>Status Codes
+        </h2>
+
+        <p>The response generated will have internal status codes for each and every event based on the input JSON provided.</p>
+        <p>Status codes are generated according to the below tables.</p>
+
+        <h3>Internal status codes</h3>
+        <table class="wikitable">
+            <tr>
+                <th style="text-align:left;">Status code</th>
+                <th style="text-align:left;">Result</th>
+                <th style="text-align:left;">Message</th>
+                <th style="text-align:left;">Comment</th>
+            </tr>
+            <tr>
+                <td>200</td>
+                <td>SUCCESS</td>
+                <td>Event sent successfully</td>
+                <td>Is returned if the request is completed successfully.</td>
+            </tr>
+            <tr>
+                <td>207</td>
+                <td>Multi-Status</td>
+                <td></td>
+                <td>Is returned if we have a mix of internal status codes.<br>
+                    Eg: publish of few events was successful and few events was a failure.<br>
+                    In case of multiple events in the body JSON, if a event is given internal status code of 400 or 500 rest events will not be
+                    published and will be given a internal status code of 503, which will result in overall HTTP response code of 207.
+                </td>
+            </tr>
+            <tr>
+                <td>400</td>
+                <td>Bad Request</td>
+                <td>Invalid event content, client need to fix problem in event before submitting again</td>
+                <td>Is returned if the request body JSON is malformed. Eg: unable to parse the body JSON.</td>
+            </tr>
+            <tr>
+                <td>404</td>
+                <td>RabbitMQ properties not found</td>
+                <td>RabbitMQ properties not configured for the protocol &lt;protocol&gt;</td>
+                <td>Is returned if RabbitMQ message broker properties are not found for the protocol used by event.</td>
+            </tr>
+            <tr>
+                <td rowspan="2">500</td>
+                <td rowspan="2">Internal Server Error</td>
+                <td>RabbitMQ is down. Please try later</td>
+                <td>Is returned if RabbitMQ is down.</td>
+            </tr>
+            <tr>
+                <td>Could not prepare Routing key to publish message.</td>
+                <td>Is returned if could not prepare routing key to publish the eiffel event.</td>
+            </tr>
+            <tr>
+                <td>503</td>
+                <td>Service Unavailable</td>
+                <td>Please check previous event and try again later</td>
+                <td>Is returned if there is a failure in publishing previous event with status code 400, 404 or 500.</td>
+            </tr>
+        </table>
+
+        <h4>Status codes explanation</h4>
+
+        <h5>200 OK</h5>
+        <p>All the events are sent successfully.</p>
+<pre>[
+    {
+     "id": "9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+     "status_code": 200,
+     "result": "SUCCESS",
+     "message": "Event sent successfully"
+    },
+    {
+     "id": "9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
+     "status_code": 200,
+     "result": "SUCCESS",
+     "message": "Event sent successfully"
+    }
+]</pre>
+
+        <h5>207 Multi-Status</h5>
+        <p>Events are having different internal status codes.</p>
+        <pre>[
+    {
+     "id": "9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+     "status_code": 200,
+     "result": "SUCCESS",
+     "message": "Event sent successfully"
+    },
+    {
+     "status_code": 400,
+     "result": "Bad Request",
+     "message": "Invalid event content, client need to fix problem in event before submitting again"
+    }
+]</pre>
+
+        <h5>400 Bad Request</h5>
+        <p>The input JSON is malformed.</p>
+<pre>[
+    {
+     "status_code": 400,
+     "result": "Bad Request",
+     "message": "Invalid event content, client need to fix problem in event before submitting again"
+    }
+]</pre>
+
+        <h5>404 Not Found</h5>
+        <p>RabbitMQ properties not configured in tomcat/conf/config.properties file for the protocol.</p>
+<pre>[
+    {
+     "status_code": 404,
+     "result": "RabbitMQ properties not found",
+     "message": "RabbitMQ properties not configured for the protocol &lt;protocol&gt;"
+    }
+]</pre>
+
+        <h5>500 Internal Server Error</h5>
+        <p>Cannot prepare routing key.</p>
+<pre>[
+    {
+     "status_code": 500,
+     "result": "Internal Server Error",
+     "message": "Could not prepare Routing key to publish message"
+    }
+]</pre>
+
+        <p>Event is failed to send because of internal server error.</p>
+        <pre>[
+    {
+     "id": "9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+     "status_code": 500,
+     "result": "Internal Server Error",
+     "message": "RabbitMQ is down. Please try later"
+    }
+]</pre>
+
+        <h5>503 Service Unavailable</h5>
+        <p>Event will have this status code when the previous event is failed to send.</p>
+        <p>For example, consider you have 5 events: <strong>E1<-E2<-E3<-E4<-E5</strong><br>
+            You send them all to publish in a batch command.<br>
+            <strong>E1</strong> and <strong>E2</strong> are sent successfully <strong>(200 OK)</strong>.<br>
+            <strong>E3</strong> is malformed <strong>(400 Bad Request)</strong>.<br>
+            If we send <strong>E4</strong> and <strong>E5</strong> we will have a broken chain so that is not a good option.<br>
+            In this case we should skip sending <strong>E4</strong> and <strong>E5</strong> and have status code <strong>503</strong> for those.
+        </p>
+        <pre>[
+     {
+      "id": "9cdd0f68-df85-44b0-88bd-fc4163ac90a0",
+      "status_code": 200,
+      "result": "SUCCESS",
+      "message": "Event sent successfully"
+     },
+     {
+      "id": "9cdd0f68-df85-44b0-88bd-fc4163ac90a1",
+      "status_code": 200,
+      "result": "SUCCESS",
+      "message": "Event sent successfully"
+     },
+     {
+      "status_code": 400,
+      "result": "Bad Request",
+      "message": "Invalid event content, client need to fix problem in event before submitting again"
+     },
+     {
+      "status_code": 503,
+      "result": "Service Unavailable",
+      "message": "Please check previous event and try again later"
+     },
+     {
+      "status_code": 503,
+      "result": "Service Unavailable",
+      "message": "Please check previous event and try again later"
+     }
+]</pre>
+
+        <p><strong>NOTE:</strong> you can open the RabbitMQ's management console and find these messages in a queue.</p>
+
+        <h3>Status codes related to failures in Eiffel REMReM Generate Service</h3>
+        <table class="wikitable">
+            <tr>
+                <th style="text-align:left;">Status code</th>
+                <th style="text-align:left;">Result</th>
+                <th style="text-align:left;">Message</th>
+                <th style="text-align:left;">Comment</th>
+            </tr>
+            <tr>
+                <td>400</td>
+                <td>Bad Request</td>
+                <td>Malformed JSON or incorrect type of event</td>
+                <td>Is returned if the request body JSON is malformed or entered incorrect type of event.</td>
+            </tr>
+            <tr>
+                <td>401</td>
+                <td>Unauthorized</td>
+                <td>Unauthorized. Please, check if LDAP for REMReM Generate Service is disabled</td>
+                <td>Is returned if LDAP for REMReM Generate Service is enabled and REMReM Generate Publish have not access to it.</td>
+            </tr>
+            <tr>
+                <td>500</td>
+                <td>Internal Server Error</td>
+                <td>Internal server error in Generate Service</td>
+                <td>Is returned if REMReM Generate Service is not started or in case of others internal errors in REMReM Generate Service.</td>
+            </tr>
+            <tr>
+                <td>503</td>
+                <td>Service Unavailable</td>
+                <td>Message protocol is invalid</td>
+                <td>Is returned if there is no such message protocol loaded.</td>
+            </tr>
+        </table>
+
+        <h4>Status codes explanation</h4>
+
+        <h5>400 Bad Request</h5>
+        <p>The input JSON is malformed or entered incorrect type of event.</p>
+<pre>[
+    {
+     "status_code": 400,
+     "result": "FAIL",
+     "message": "Malformed JSON or incorrect type of event"
+    }
+]</pre>
+
+        <h5>401 Unauthorized</h5>
+        <p>LDAP for REMReM Generate Service is enabled and REMReM Generate Publish have not access to it.</p>
+<pre>[
+    {
+     "status_code": 401,
+     "result": "FAIL",
+     "message": "Unauthorized. Please, check if LDAP for REMReM Generate Service is disabled"
+    }
+]</pre>
+
+        <h5>500 Internal Server Error</h5>
+        <p>REMReM Generate Service is not started or in case of others internal errors in REMReM Generate Service.</p>
+<pre>[
+    {
+     "status_code": 500,
+     "result": "FAIL",
+     "message": "Internal server error in Generate Service"
+    }
+]</pre>
+
+        <h5>503 Service Unavailable</h5>
+        <p>There is no such message protocol loaded..</p>
+<pre>[
+     {
+      "status_code": 503,
+      "result": "FAIL",
+      "message": "Message protocol is invalid"
+     }
+]</pre>
+
+    </section>
+</div>
+
+<!-- FOOTER  -->
+<div id="footer_wrap" class="outer">
+    <footer class="inner">
+        <p class="copyright">Eiffel REMReM Publish maintained by <a href="https://github.com/ericsson">Ericsson</a></p>
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/statusCodes.html
+++ b/statusCodes.html
@@ -32,21 +32,15 @@
     <section id="main_content" class="inner">
 
         <h1>
-            <a id="remrem-publish-service" class="anchor" href="#remrem-publish-service" aria-hidden="true">
-                <span aria-hidden="true" class="octicon octicon-link"></span>
-            </a>REMReM Publish Service
-        </h1>
-
-        <h2>
             <a id="statusCodes" class="anchor" href="#statusCodes" aria-hidden="true">
                 <span aria-hidden="true" class="octicon octicon-link"></span>
             </a>Status Codes
-        </h2>
+        </h1>
 
         <p>The response generated will have internal status codes for each and every event based on the input JSON provided.</p>
         <p>Status codes are generated according to the below tables.</p>
 
-        <h3>Internal status codes</h3>
+        <h2>Internal status codes</h2>
         <table class="wikitable">
             <tr>
                 <th style="text-align:left;">Status code</th>
@@ -100,7 +94,7 @@
             </tr>
         </table>
 
-        <h4>Status codes explanation</h4>
+        <h3>Status codes explanation</h3>
 
         <h5>200 OK</h5>
         <p>All the events are sent successfully.</p>
@@ -216,7 +210,7 @@
 
         <p><strong>NOTE:</strong> you can open the RabbitMQ's management console and find these messages in a queue.</p>
 
-        <h3>Status codes related to failures in Eiffel REMReM Generate Service</h3>
+        <h2>Status codes related to failures in Eiffel REMReM Generate Service</h2>
         <p>These response can be generated only when <code>/generateAndPublish</code> endpoint is used.</p>
 
         <table class="wikitable">
@@ -252,7 +246,7 @@
             </tr>
         </table>
 
-        <h4>Status codes explanation</h4>
+        <h3>Status codes explanation</h3>
 
         <h5>400 Bad Request</h5>
         <p>The input JSON is malformed or entered incorrect type of event.</p>

--- a/statusCodes.html
+++ b/statusCodes.html
@@ -217,6 +217,8 @@
         <p><strong>NOTE:</strong> you can open the RabbitMQ's management console and find these messages in a queue.</p>
 
         <h3>Status codes related to failures in Eiffel REMReM Generate Service</h3>
+        <p>These response can be generated only when <code>/generateAndPublish</code> endpoint is used.</p>
+
         <table class="wikitable">
             <tr>
                 <th style="text-align:left;">Status code</th>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -266,7 +266,7 @@ Full-Width Styles
 
 .inner {
   position: relative;
-  max-width: 1200px;
+  max-width: 1024px;
   padding: 20px 10px;
   margin: 0 auto;
 }
@@ -305,6 +305,7 @@ Full-Width Styles
   font-size: 42px;
   font-weight: 700;
   text-shadow: #111 0px 0px 10px;
+  text-decoration: none;
 }
 
 .project_title:hover {

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -299,12 +299,16 @@ Full-Width Styles
   padding: 50px 10px 30px 10px;
 }
 
-#project_title {
+.project_title {
   margin: 0;
-  color: #fff;
+  color: #fff !important;
   font-size: 42px;
   font-weight: 700;
   text-shadow: #111 0px 0px 10px;
+}
+
+.project_title:hover {
+  text-decoration: none;
 }
 
 #project_tagline {


### PR DESCRIPTION
REMReM Publish documentation was restructured.
Documentation was splited into 4 paths.

1. Main page
- Introduction
- Compatibility
- Components
- Installation
- Usage
- Logging

2. REMReM Publish CLI
- Usage
- Examples

3. REMReM Publish Service
- Configuration
- Usage
- Examples

4. Status Codes
