### PR TITLE
Uplift spring boot from 2.7.8 to 4.0.6 version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.eiffel-community</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>2.1.12</eiffel-remrem-publish.version>
-        <eiffel-remrem-semantics.version>2.4.4</eiffel-remrem-semantics.version>
+        <eiffel-remrem-publish.version>2.1.13</eiffel-remrem-publish.version>
+        <eiffel-remrem-semantics.version>2.4.6</eiffel-remrem-semantics.version>
         <logback.version>1.5.32</logback.version>
         <slf4j.version>2.0.17</slf4j.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,14 @@
     <parent>
         <groupId>com.github.eiffel-community</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>2.0.18</version>
+        <version>2.0.19</version>
     </parent>
     <properties>
         <eiffel-remrem-publish.version>2.1.12</eiffel-remrem-publish.version>
-        <eiffel-remrem-semantics.version>2.4.2</eiffel-remrem-semantics.version>
+        <eiffel-remrem-semantics.version>2.4.4</eiffel-remrem-semantics.version>
+        <logback.version>1.5.32</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     </properties>
     <artifactId>eiffel-remrem-publish</artifactId>
     <version>${eiffel-remrem-publish.version}</version>
@@ -44,6 +47,11 @@
                 <dependencies>
                 </dependencies>
         </plugin>
+    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
     <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.eiffel-community</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>2.0.20</version>
+        <version>2.0.21</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>2.1.14</eiffel-remrem-publish.version>
+        <eiffel-remrem-publish.version>2.1.15</eiffel-remrem-publish.version>
         <eiffel-remrem-semantics.version>2.4.6</eiffel-remrem-semantics.version>
         <logback.version>1.5.32</logback.version>
         <slf4j.version>2.0.17</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <properties>
         <eiffel-remrem-publish.version>2.1.17</eiffel-remrem-publish.version>
-        <eiffel-remrem-semantics.version>2.4.6</eiffel-remrem-semantics.version>
+        <eiffel-remrem-semantics.version>2.4.7</eiffel-remrem-semantics.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     </properties>
     <artifactId>eiffel-remrem-publish</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,11 @@
     <parent>
         <groupId>com.github.eiffel-community</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>2.0.21</version>
+        <version>2.0.22</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>2.1.15</eiffel-remrem-publish.version>
+        <eiffel-remrem-publish.version>2.1.17</eiffel-remrem-publish.version>
         <eiffel-remrem-semantics.version>2.4.6</eiffel-remrem-semantics.version>
-        <logback.version>1.5.32</logback.version>
-        <slf4j.version>2.0.17</slf4j.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     </properties>
     <artifactId>eiffel-remrem-publish</artifactId>

--- a/publish-cli/pom.xml
+++ b/publish-cli/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-cli/pom.xml
+++ b/publish-cli/pom.xml
@@ -23,10 +23,6 @@
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>logback-classic</artifactId>
-                    <groupId>ch.qos.logback</groupId>
-                </exclusion>
-                <exclusion>
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                     <groupId>org.springframework.boot</groupId>
                 </exclusion>
@@ -70,6 +66,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.eiffel-community</groupId>
             <artifactId>eiffel-remrem-semantics</artifactId>
             <version>${eiffel-remrem-semantics.version}</version>
@@ -88,8 +88,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -97,16 +98,7 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${springboot.version}</version>
             <scope>test</scope>
-            <exclusions>
-            	<exclusion>
-            		<groupId>org.junit.jupiter</groupId>
-            		<artifactId>junit-jupiter</artifactId>
-            	</exclusion>
-            	<exclusion>
-            		<groupId>org.mockito</groupId>
-            		<artifactId>mockito-junit-jupiter</artifactId>
-            	</exclusion>
-            </exclusions>
+
         </dependency>
     </dependencies>
     <build>
@@ -130,7 +122,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <includes>
                         <include>**/*.class</include>

--- a/publish-cli/pom.xml
+++ b/publish-cli/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-cli/src/test/java/com/ericsson/eiffel/remrem/publish/cli/CliOptionsUnitTests.java
+++ b/publish-cli/src/test/java/com/ericsson/eiffel/remrem/publish/cli/CliOptionsUnitTests.java
@@ -14,15 +14,15 @@
 */
 package com.ericsson.eiffel.remrem.publish.cli;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
 import com.ericsson.eiffel.remrem.publish.cli.CliOptions;;
@@ -31,7 +31,7 @@ public class CliOptionsUnitTests {
     private PrintStream console;
     private ByteArrayOutputStream bytes;
 
-    @Before public void setUp() throws Exception {
+    @BeforeEach public void setUp() throws Exception {
         String key = PropertiesConfig.TEST_MODE;
         System.setProperty(key, "true");
         //Switch std out to another stream
@@ -40,7 +40,7 @@ public class CliOptionsUnitTests {
         System.setOut(new PrintStream(bytes));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         System.clearProperty(PropertiesConfig.TEST_MODE);
         System.setOut(console);
@@ -81,7 +81,7 @@ public class CliOptionsUnitTests {
     }
 
     @Test
-    @Ignore // Why TLS 1.3 should not be accepted? Ignoring the test...
+    @Disabled // Why TLS 1.3 should not be accepted? Ignoring the test...
     public void testTlsVer13OptionFails() throws Exception {
         String[] args = {"-f", "/a/b/c/test.file",  "test", "-tls", "1.3"};
         CliOptions.parse(args);

--- a/publish-cli/src/test/java/com/ericsson/eiffel/remrem/publish/cli/CliUnitTests.java
+++ b/publish-cli/src/test/java/com/ericsson/eiffel/remrem/publish/cli/CliUnitTests.java
@@ -14,20 +14,20 @@
 */
 package com.ericsson.eiffel.remrem.publish.cli;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.io.File;
 import java.util.List;
 
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.ericsson.eiffel.remrem.protocol.MsgService;
 import com.ericsson.eiffel.remrem.publish.helper.PublishUtils;
@@ -37,9 +37,9 @@ import com.ericsson.eiffel.remrem.publish.service.PublishResultItem;
 import com.ericsson.eiffel.remrem.publish.service.SendResult;
 import com.google.gson.JsonArray;
 import org.mockito.*;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CliUnitTests {
     private PrintStream console;
     private ByteArrayOutputStream bytes;
@@ -64,7 +64,7 @@ public class CliUnitTests {
 
     private MockedStatic<PublishUtils> publishUtils;
 
-    @Before public void setUp() throws Exception {
+    @BeforeEach public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         String key = PropertiesConfig.TEST_MODE;
         System.setProperty(key, "true");
@@ -78,7 +78,7 @@ public class CliUnitTests {
                 .thenReturn(eiffelsemanticsMsgService);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         System.clearProperty(PropertiesConfig.TEST_MODE);
         System.setOut(console);

--- a/publish-common/pom.xml
+++ b/publish-common/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>2.3.8.RELEASE</version>
+            <version>3.2.14</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -122,8 +122,9 @@
             <version>2.18.6</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-common/pom.xml
+++ b/publish-common/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
@@ -124,7 +123,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-common/pom.xml
+++ b/publish-common/pom.xml
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>3.2.14</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.8.0</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-common/pom.xml
+++ b/publish-common/pom.xml
@@ -114,11 +114,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.21.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.6</version>
+            <version>2.21.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/RabbitMqPropertiesConfig.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/RabbitMqPropertiesConfig.java
@@ -33,12 +33,13 @@ import com.ericsson.eiffel.remrem.publish.service.GenerateURLTemplate;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 public class RabbitMqPropertiesConfig {
 
-    static Logger log = (Logger) LoggerFactory.getLogger(RabbitMqPropertiesConfig.class);
+    static Logger log = LoggerFactory.getLogger(RabbitMqPropertiesConfig.class);
 
     @Autowired
     Environment env;

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/SpringLoggingInitializer.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/SpringLoggingInitializer.java
@@ -27,6 +27,11 @@ import ch.qos.logback.classic.Logger;
 
 public class SpringLoggingInitializer implements ApplicationContextInitializer {
 
+    /* (non-Javadoc)
+     * @see org.springframework.context.ApplicationContextInitializer#initialize(org.springframework.context.ConfigurableApplicationContext)
+     *
+     * We need to turn off Spring logging since we want write the generated message to console.
+     */
 	@Override
 	public void initialize(ConfigurableApplicationContext applicationContext) {
 		Class[] loggers = {SpringApplication.class, ConfigDataEnvironmentPostProcessor.class, EndpointMBean.class,

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/SpringLoggingInitializer.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/SpringLoggingInitializer.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.endpoint.jmx.EndpointMBean;
 import org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -27,19 +27,14 @@ import ch.qos.logback.classic.Logger;
 
 public class SpringLoggingInitializer implements ApplicationContextInitializer {
 
-	/* (non-Javadoc)
-	 * @see org.springframework.context.ApplicationContextInitializer#initialize(org.springframework.context.ConfigurableApplicationContext)
-	 * 
-	 * We need to turn off Spring logging since we want write the generated message to console. 
-	 */
 	@Override
 	public void initialize(ConfigurableApplicationContext applicationContext) {
-		Class[] loggers = {SpringApplication.class, /*App.class,*/ ConfigFileApplicationListener.class, EndpointMBean.class,
+		Class[] loggers = {SpringApplication.class, ConfigDataEnvironmentPostProcessor.class, EndpointMBean.class,
 		        ConditionEvaluationReportLoggingListener.class};
-		Logger log = (Logger) LoggerFactory.getLogger("ROOT");
+		ch.qos.logback.classic.Logger log = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("ROOT");
 		log.setLevel(Level.ERROR);
 		for (Class logger : loggers) {
-			log = (Logger) LoggerFactory.getLogger(logger);
+			log = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(logger);
 			log.setLevel(Level.ERROR);
 		}
 	}

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/PublishUtils.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/PublishUtils.java
@@ -21,11 +21,11 @@ import com.ericsson.eiffel.remrem.protocol.MsgService;
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
 import com.google.gson.JsonObject;
 
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
 
 public class PublishUtils {
 
-    static Logger log = (Logger) LoggerFactory.getLogger(PublishUtils.class);
+    static Logger log = LoggerFactory.getLogger(PublishUtils.class);
     /**
      * Method returns the MsgService based on the mp(message protocol) from the list of MsgService beans. 
      * @param mp(message protocol) Specifies which service we consider from the list of MsgService beans

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RMQHelper.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RMQHelper.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,8 +36,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component("rmqHelper") public class RMQHelper {
 
@@ -49,7 +49,7 @@ import ch.qos.logback.classic.Logger;
 
     Map<String, RabbitMqProperties> rabbitMqPropertiesMap = new HashMap<String, RabbitMqProperties>();
 
-    Logger log = (Logger) LoggerFactory.getLogger(RMQHelper.class);
+    Logger log = LoggerFactory.getLogger(RMQHelper.class);
 
     public Map<String, RabbitMqProperties> getRabbitMqPropertiesMap() {
         return rabbitMqPropertiesMap;
@@ -132,10 +132,8 @@ import ch.qos.logback.classic.Logger;
     @PostConstruct
     private void handleLogging() {
         String debug = System.getProperty(PropertiesConfig.DEBUG);
-        log.setLevel(Level.ALL);
         if (FALSE.equals(debug)) {
             System.setProperty("logging.level.root", "OFF");
-            log.setLevel(Level.OFF);
         }
     }
 

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
@@ -25,6 +25,7 @@ import java.util.*;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
@@ -38,8 +39,6 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.MessageProperties;
 import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
-
-import ch.qos.logback.classic.Logger;
 
 public class RabbitMqProperties {
 
@@ -81,7 +80,7 @@ public class RabbitMqProperties {
     private final String TYPE = "type";
     private final String DOT = ".";
 
-    Logger log = (Logger) LoggerFactory.getLogger(RMQHelper.class);
+    Logger log = LoggerFactory.getLogger(RabbitMqProperties.class);
 
     static {
         PERSISTENT_BASIC_APPLICATION_JSON =

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/EventTemplateHandler.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/EventTemplateHandler.java
@@ -14,9 +14,9 @@
 */
 package com.ericsson.eiffel.remrem.publish.service;
 
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.ericsson.eiffel.remrem.semantics.EiffelEventType;
-import com.ericsson.eiffel.semantics.events.Event;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,7 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class EventTemplateHandler {
-    private static final Logger log = (Logger) LoggerFactory.getLogger(EventTemplateHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(EventTemplateHandler.class);
 
     // Paths in Semantics JAR
     private static final String EVENT_TEMPLATE_PATH = "templates/";

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImpl.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImpl.java
@@ -41,14 +41,15 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service("messageServiceRMQImpl") public class MessageServiceRMQImpl
     implements MessageService {
 
     @Autowired @Qualifier("rmqHelper") RMQHelper rmqHelper;
     
-    Logger log = (Logger) LoggerFactory.getLogger(MessageServiceRMQImpl.class);
+    Logger log = LoggerFactory.getLogger(MessageServiceRMQImpl.class);
     
     /*
      * (non-Javadoc)

--- a/publish-common/src/test/java/com/ericsson/eiffel/remrem/publish/helper/RMQHelperUnitTest.java
+++ b/publish-common/src/test/java/com/ericsson/eiffel/remrem/publish/helper/RMQHelperUnitTest.java
@@ -14,10 +14,10 @@
 */
 package com.ericsson.eiffel.remrem.publish.helper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -26,19 +26,19 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
 import com.ericsson.eiffel.remrem.publish.config.RabbitMqPropertiesConfig;
 import com.ericsson.eiffel.remrem.publish.exception.RemRemPublishException;
 import com.rabbitmq.client.Connection;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RMQHelperUnitTest {
 
     private static final String mBusHost= "HostA";
@@ -69,7 +69,7 @@ public class RMQHelperUnitTest {
 
     Map<String, RabbitMqProperties> rabbitMqPropertiesMap = new HashMap<String, RabbitMqProperties>();
 
-    @Before public void setUp() throws Exception {
+    @BeforeEach public void setUp() throws Exception {
         Mockito.when(factory.newConnection()).thenReturn(mockConnection);
         Mockito.when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -89,7 +89,7 @@ public class RMQHelperUnitTest {
         }
     }
 
-    @After public void tearDown() throws Exception {
+    @AfterEach public void tearDown() throws Exception {
         cleanProperties();
         rmqHelper.cleanUp();
     }

--- a/publish-service/pom.xml
+++ b/publish-service/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
@@ -126,13 +125,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
-            <version>${springboot.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-service/pom.xml
+++ b/publish-service/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.8</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/publish-service/pom.xml
+++ b/publish-service/pom.xml
@@ -73,8 +73,8 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.8.0</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
@@ -130,8 +130,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -143,10 +144,6 @@
                 <exclusion>
                     <artifactId>json-path</artifactId>
                     <groupId>com.jayway.jsonpath</groupId>
-                </exclusion>
-                <exclusion>
-                	<groupId>org.junit.jupiter</groupId>
-                	<artifactId>junit-jupiter</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -243,11 +240,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!-- Allow JUnit to access the test classes -->
-                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                    <argLine>--add-opens java.base/jdk.internal.reflect=ALL-UNNAMED</argLine>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/App.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/App.java
@@ -20,6 +20,7 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.ApplicationContext;
@@ -28,7 +29,7 @@ import org.springframework.context.annotation.ComponentScan;
 import com.ericsson.eiffel.remrem.publish.config.SpringLoggingInitializer;
 
 @SpringBootApplication(scanBasePackages = {"com.ericsson.eiffel.remrem"})
-@EnableAutoConfiguration(exclude = { JacksonAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = { JacksonAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class, LdapAutoConfiguration.class})
 public class App extends SpringBootServletInitializer {
  
     public static void main(String[] args) {

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/App.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/App.java
@@ -19,9 +19,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
-import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
@@ -29,7 +28,7 @@ import org.springframework.context.annotation.ComponentScan;
 import com.ericsson.eiffel.remrem.publish.config.SpringLoggingInitializer;
 
 @SpringBootApplication(scanBasePackages = {"com.ericsson.eiffel.remrem"})
-@EnableAutoConfiguration(exclude = { JacksonAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class, LdapAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = { JacksonAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 public class App extends SpringBootServletInitializer {
  
     public static void main(String[] args) {

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
@@ -2,9 +2,9 @@ package com.ericsson.eiffel.remrem.publish.config;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/DisabledSecurityConfig.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/DisabledSecurityConfig.java
@@ -22,6 +22,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * This class is used to disable the ldap authentication based on property
+ * activedirectory.publish.enabled = false in property file. By default this
+ * class will execute.
+ *
+ */
 @Profile("!integration-test")
 @ConditionalOnProperty(value = "activedirectory.publish.enabled", havingValue = "false", matchIfMissing = true)
 @Configuration
@@ -30,6 +36,12 @@ public class DisabledSecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+             // The application uses non-browser clients. Yes, there is swagger interface,
+             // but is's used only for testing/tuning.
+             //
+             // From https://docs.spring.io/spring-security/reference/features/exploits/csrf.html
+             // "If you are creating a service that is used only by non-browser clients,
+             //  you likely want to disable CSRF protection."
             .csrf(csrf -> csrf.disable());
         return http.build();
     }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/DisabledSecurityConfig.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/DisabledSecurityConfig.java
@@ -15,25 +15,22 @@
 package com.ericsson.eiffel.remrem.publish.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
-/**
- * This class is used to disable the ldap authentication based on property
- * activedirectory.publish.enabled = false in property file. By default this
- * class will execute.
- * 
- */
 @Profile("!integration-test")
 @ConditionalOnProperty(value = "activedirectory.publish.enabled", havingValue = "false", matchIfMissing = true)
 @Configuration
 @EnableWebSecurity
-public class DisabledSecurityConfig extends WebSecurityConfigurerAdapter {
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests().anyRequest().permitAll().and().csrf().disable();
+public class DisabledSecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .csrf(csrf -> csrf.disable());
+        return http.build();
     }
 }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/GsonHttpMessageConverterConfig.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/GsonHttpMessageConverterConfig.java
@@ -18,10 +18,16 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
 
 @Configuration
 public class GsonHttpMessageConverterConfig {
+
+        @Bean
+        public ByteArrayHttpMessageConverter byteArrayHttpMessageConverter() {
+                return new ByteArrayHttpMessageConverter();
+        }
 
         @Bean
         public GsonHttpMessageConverter gsonHttpMessageConverter() {

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/GsonHttpMessageConverterWithValidate.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/GsonHttpMessageConverterWithValidate.java
@@ -55,7 +55,7 @@ public class GsonHttpMessageConverterWithValidate extends GsonHttpMessageConvert
             mapper.readTree(json);
             return this.gson.fromJson(json, resolvedType);
         } catch (JsonParseException ex) {
-            throw new HttpMessageNotReadableException("Could not read JSON: " + ex.getMessage(), ex);
+            throw new HttpMessageNotReadableException("Could not read JSON: " + ex.getMessage(), ex, null);
         }
         
     }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
@@ -21,18 +21,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.ldap.authentication.BindAuthenticator;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
-
-import static org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.disable;
+import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * This class is used to enable the ldap authentication based on property
@@ -43,7 +44,7 @@ import static org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.dis
 @Configuration
 @ConditionalOnProperty(value = "activedirectory.publish.enabled")
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SecurityConfig.class);
 
@@ -78,8 +79,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
-    @Override
-    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+    @Bean
+    public AuthenticationProvider ldapAuthenticationProvider() {
         final String jasyptKey = RabbitMqPropertiesConfig.readJasyptKeyFile(jasyptKeyFilePath);
         if (managerPassword.startsWith("{ENC(") && managerPassword.endsWith("}")) {
             managerPassword = DecryptionUtils.decryptString(
@@ -87,21 +88,22 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         }
         LOGGER.debug("LDAP server url: " + ldapUrl);
 
-        // Initialize and configure the LdapContextSource
         LdapContextSource contextSource = ldapContextSource();
 
-        // Configure BindAuthenticator with the context source and user search filter
         BindAuthenticator bindAuthenticator = new BindAuthenticator(contextSource);
         bindAuthenticator.setUserSearch(new FilterBasedLdapUserSearch(
-                "",  // Empty base indicates search starts at root DN provided in contextSource
+                "",
                 userSearchFilter,
                 contextSource));
 
-        // Setup LdapAuthenticationProvider
-        LdapAuthenticationProvider ldapAuthProvider = new LdapAuthenticationProvider(bindAuthenticator);
+        return new LdapAuthenticationProvider(bindAuthenticator);
+    }
 
-        // Configure the authentication provider
-        auth.authenticationProvider(ldapAuthProvider);
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        builder.authenticationProvider(ldapAuthenticationProvider());
+        return builder.build();
     }
 
     public LdapContextSource ldapContextSource() {
@@ -117,23 +119,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         return ldap;
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         LOGGER.debug("LDAP authentication enabled");
-        http.authorizeRequests()
-            .anyRequest()
-            .authenticated()
-            .and()
-            .httpBasic()
-            .authenticationEntryPoint(customAuthenticationEntryPoint)
-            .and()
-            .csrf()
-            // The application uses non-browser clients. Yes, there is swagger interface,
-            // but is's used only for testing/tuning.
-            //
-            // From https://docs.spring.io/spring-security/reference/features/exploits/csrf.html
-            // "If you are creating a service that is used only by non-browser clients,
-            //  you likely want to disable CSRF protection."
-            .disable();
+        http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic(basic -> basic.authenticationEntryPoint(customAuthenticationEntryPoint))
+            .csrf(csrf -> csrf.disable());
+        return http.build();
     }
 }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/SecurityConfig.java
@@ -88,11 +88,13 @@ public class SecurityConfig {
         }
         LOGGER.debug("LDAP server url: " + ldapUrl);
 
+        // Initialize and configure the LdapContextSource
         LdapContextSource contextSource = ldapContextSource();
 
+        // Configure BindAuthenticator with the context source and user search filter
         BindAuthenticator bindAuthenticator = new BindAuthenticator(contextSource);
         bindAuthenticator.setUserSearch(new FilterBasedLdapUserSearch(
-                "",
+                "", // Empty base indicates search starts at root DN provided in contextSource
                 userSearchFilter,
                 contextSource));
 
@@ -124,6 +126,12 @@ public class SecurityConfig {
         LOGGER.debug("LDAP authentication enabled");
         http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
             .httpBasic(basic -> basic.authenticationEntryPoint(customAuthenticationEntryPoint))
+            // The application uses non-browser clients. Yes, there is swagger interface,
+            // but is's used only for testing/tuning.
+            //
+            // From https://docs.spring.io/spring-security/reference/features/exploits/csrf.html
+            // "If you are creating a service that is used only by non-browser clients,
+            //  you likely want to disable CSRF protection."
             .csrf(csrf -> csrf.disable());
         return http.build();
     }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/SwaggerConfig.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/SwaggerConfig.java
@@ -16,7 +16,7 @@ package com.ericsson.eiffel.remrem.publish.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import org.springdoc.core.GroupedOpenApi;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -444,7 +444,7 @@ public class ProducerController {
             }
 
             if (responseStatus == HttpStatus.OK || responseStatus == HttpStatus.MULTI_STATUS) {
-                log.info("The result from REMReM Generate is: " + response.getStatusCodeValue());
+                log.info("The result from REMReM Generate is: " + response.getStatusCode().value());
                 log.debug("mp: " + msgProtocol);
                 log.debug("body: " + responseBody);
                 log.debug("user domain suffix: " + userDomain + " tag: " + tag + " routing key: " + routingKey);

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -52,7 +52,7 @@ import com.ericsson.eiffel.remrem.publish.helper.PublishUtils;
 import com.ericsson.eiffel.remrem.publish.helper.RMQHelper;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import ch.qos.logback.classic.Logger;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -88,7 +88,7 @@ public class ProducerController {
 
     private JsonParser parser = new JsonParser();
 
-    private Logger log = (Logger) LoggerFactory.getLogger(ProducerController.class);
+    private org.slf4j.Logger log = LoggerFactory.getLogger(ProducerController.class);
 
     public final String JSON_STATUS_RESULT = "result";
 
@@ -433,7 +433,7 @@ public class ProducerController {
             ResponseEntity<String> response = restTemplate.postForEntity(generatedUrl,
                     entity, String.class, generateURLTemplate.getMap(msgProtocol, msgType));
 
-            responseStatus = response.getStatusCode();
+            responseStatus = HttpStatus.valueOf(response.getStatusCode().value());
             String responseBody = null;
             // TODO We should not rely on bodyJson (an input string), but rather on given
             //      result, i.e. response.getBody() and check this for type (object or array).

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/VersionService.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/VersionService.java
@@ -26,7 +26,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
 import com.google.gson.JsonParser;
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -42,7 +42,7 @@ public class VersionService {
     private static final String IS_ENDPOINT_VERSION = "isEndpointVersion";
     private static final String ENDPOINT_VERSION = "endpointVersions";
     private static final String SERVICE_VERSION = "serviceVersion";
-    private Logger log = (Logger) LoggerFactory.getLogger(VersionService.class);
+    private Logger log = LoggerFactory.getLogger(VersionService.class);
     JsonParser parser = new JsonParser();
     Map<String, Map<String, String>> versions = new HashMap<>();
     Map<String, String> endpointVersions = new HashMap<String, String>();

--- a/publish-service/src/main/resources/application.properties
+++ b/publish-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 
-server.port=8081
+server.port=8080
 debug: false
   
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER

--- a/publish-service/src/main/resources/application.properties
+++ b/publish-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 
-server.port=8080
+server.port=8081
 debug: false
   
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/integrationtest/EiffelRemRemPublishIT.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/integrationtest/EiffelRemRemPublishIT.java
@@ -15,7 +15,7 @@
 package com.ericsson.eiffel.remrem.publish.integrationtest;
 
 import static io.restassured.RestAssured.given;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileReader;
@@ -24,16 +24,14 @@ import java.util.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.ericsson.eiffel.remrem.protocol.MsgService;
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
@@ -51,7 +49,6 @@ import com.google.gson.JsonParser;
 import io.restassured.RestAssured;
 
 @ActiveProfiles("integration-test")
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
 public class EiffelRemRemPublishIT {
     @Value("${local.server.port}")
@@ -67,7 +64,7 @@ public class EiffelRemRemPublishIT {
     @Autowired
     RMQHelper rmqHelper;
 
-    @Before
+    @BeforeEach
     public void setUp() throws RemRemPublishException {
         RestAssured.port = port;
         rmqHelper.rabbitMqPropertiesInit(protocol);

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/integrationtest/TestSecurityConfig.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/integrationtest/TestSecurityConfig.java
@@ -14,36 +14,34 @@
 */
 package com.ericsson.eiffel.remrem.publish.integrationtest;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Profile("integration-test")
 @Configuration
 @EnableWebSecurity
-public class TestSecurityConfig extends WebSecurityConfigurerAdapter {
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth
-                .inMemoryAuthentication()
-                .withUser("user")
-                .password("{noop}secret")
-                .roles("USER");
+public class TestSecurityConfig {
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailsManager(
+                User.withUsername("user")
+                    .password("{noop}secret")
+                    .roles("USER")
+                    .build());
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http
-            .authorizeRequests()
-                .anyRequest()
-                .authenticated()
-                .and()
-            .httpBasic()
-                .and()
-            .csrf()
-                .disable();
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic(basic -> {})
+            .csrf(csrf -> csrf.disable());
+        return http.build();
     }
 }

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EiffelRemremCommonControllerUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EiffelRemremCommonControllerUnitTest.java
@@ -14,7 +14,7 @@
 */
 package com.ericsson.eiffel.remrem.publish.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,9 +24,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.ericsson.eiffel.remrem.protocol.ValidationResult;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -36,7 +36,9 @@ import org.mockito.Spy;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.web.client.RestTemplate;
 
 import com.ericsson.eiffel.remrem.protocol.MsgService;
@@ -47,7 +49,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 
-@RunWith(SpringRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EiffelRemremCommonControllerUnitTest {
 
     @Mock
@@ -97,7 +100,7 @@ public class EiffelRemremCommonControllerUnitTest {
 
     private MsgService[] msgServices = new MsgService[2];
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         unit.setRestTemplate(restTemplate);

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EventTemplateHandlerTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EventTemplateHandlerTest.java
@@ -18,18 +18,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.File;
 import java.io.IOException;
-
-@RunWith(SpringJUnit4ClassRunner.class)
 public class EventTemplateHandlerTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventTemplateHandlerTest.class);

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
@@ -14,10 +14,11 @@
 */
 package com.ericsson.eiffel.remrem.publish.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -27,17 +28,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.ericsson.eiffel.remrem.protocol.MsgService;
 import com.ericsson.eiffel.remrem.publish.config.PropertiesConfig;
@@ -50,7 +48,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
 public class MessageServiceRMQImplUnitTest {
     
@@ -100,7 +97,7 @@ public class MessageServiceRMQImplUnitTest {
             rabbitmqProtocolProperties.setExchangeName(exchangeName);
             rabbitmqProtocolProperties.init();
         }
-        assertFalse("An exception occured while creating a exchange", exceptionOccured);
+        assertFalse(exceptionOccured, "An exception occured while creating a exchange");
     }
 
     /**
@@ -108,11 +105,13 @@ public class MessageServiceRMQImplUnitTest {
      * RemRemPublishException when CreateExchangeIfNotExisting is false and
      * exchange is not available.
      */
-    @Test(expected = RemRemPublishException.class)
+    @Test
     public void testCreateExchangeIfNotExistingDisable() throws RemRemPublishException  {
         rabbitmqProtocolProperties.setExchangeName("test76888");
         rabbitmqProtocolProperties.setCreateExchangeIfNotExisting(false);
-        rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();
+        org.junit.jupiter.api.Assertions.assertThrows(RemRemPublishException.class, () -> {
+            rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();
+        });
 
         rabbitmqProtocolProperties.setExchangeName(exchangeName);
         rabbitmqProtocolProperties.init();
@@ -154,7 +153,7 @@ public class MessageServiceRMQImplUnitTest {
         JsonArray jarray = new JsonArray();
         MsgService msgService = PublishUtils.getMessageService(protocol, msgServices);
         SendResult result = messageService.send(body, msgService, "test", null, null);
-        Assert.assertNotNull(result);
+        assertNotNull(result);
         String Expected="[{\"id\":null,\"status_code\":400,\"result\":\"Bad Request\",\"message\":\"Invalid event content, client need to fix problem in event before submitting again\"},{\"id\":null,\"status_code\":503,\"result\":\"Service Unavailable\",\"message\":\"Please check previous event and try again later\"},{\"id\":null,\"status_code\":503,\"result\":\"Service Unavailable\",\"message\":\"Please check previous event and try again later\"}]";
         for (PublishResultItem results : result.getEvents()) {
             jarray.add(results.toJsonObject());
@@ -168,7 +167,7 @@ public class MessageServiceRMQImplUnitTest {
         JsonArray jarray = new JsonArray();
         MsgService msgService = PublishUtils.getMessageService(protocol, msgServices);
         SendResult result = messageService.send(body, msgService, "test", null, null);
-        Assert.assertNotNull(result);
+        assertNotNull(result);
         for (PublishResultItem results : result.getEvents()) {
             jarray.add(results.toJsonObject());
         }
@@ -183,7 +182,7 @@ public class MessageServiceRMQImplUnitTest {
         MsgService msgService = PublishUtils.getMessageService(protocol, msgServices);
         while (!(jarray.toString().contains("Time out waiting for ACK"))) {
             SendResult result = messageService.send(body, msgService, "test", null, null);
-            Assert.assertNotNull(result);
+            assertNotNull(result);
             for (PublishResultItem results : result.getEvents()) {
                jarray.add(results.toJsonObject());
             }


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues

Uplift spring boot from 2.7.8 to 4.0.6 version

### Description of the Change

**Spring Boot Upgrade: 2.7.8 → 4.0.6
Parent POM (eiffel-remrem-parent)**
springboot.version	2.7.8	4.0.6	Target upgrade
spring-security-ldap.version	5.x/6.5.9	7.0.3	Spring Boot 4.0.5 requires Spring Security 7.x
 
**Dependency Version Updates**
spring-ldap-core	3.2.14	4.0.2	publish-common	Required by Spring Security LDAP 7.0.3
springdoc-openapi-ui → springdoc-openapi-starter-webmvc-ui	1.8.0	3.0.2
springdoc-openapi-starter-webmvc-ui	2.8.8	3.0.2	
junit-jupiter	5.10.2	6.0.3	
 
**javax → jakarta Migration**
RMQHelper.java	javax.annotation.PostConstruct / PreDestroy → jakarta.annotation.PostConstruct / PreDestroy
 
**Logger Migration (ch.qos.logback.classic.Logger → org.slf4j.Logger)**
RabbitMqPropertiesConfig.java	Replaced logback Logger cast with SLF4J Logger
PublishUtils.java	Same
RMQHelper.java	Same, also removed logback Level usage (log.setLevel())
RabbitMqProperties.java	Same
EventTemplateHandler.java	Same
 
**Spring Boot API Changes**
SpringLoggingInitializer.java	ConfigFileApplicationListener → ConfigDataEnvironmentPostProcessor	Class removed in Spring Boot 3.x
App.java	Updated import paths for JacksonAutoConfiguration and UserDetailsServiceAutoConfiguration to new packages	Classes relocated in Spring Boot 4.0
App.java	Removed LdapAutoConfiguration from @EnableAutoConfiguration(exclude = ...)	Class no longer exists in Spring Boot 4.0
GsonHttpMessageConverterWithValidate.java	Added null as 3rd param to HttpMessageNotReadableException constructor	Spring Framework 7 removed (String, Throwable) constructor
ProducerController.java	getStatusCodeValue() → getStatusCode().value()	Method removed in Spring Framework 7
 
 
**Spring Security Migration (WebSecurityConfigurerAdapter → SecurityFilterChain)**
DisabledSecurityConfig.java	Replaced WebSecurityConfigurerAdapter with SecurityFilterChain bean-based config
SecurityConfig.java	Same — migrated to SecurityFilterChain with HttpSecurity builder
TestSecurityConfig.java	Same — migrated test security config to SecurityFilterChain
CustomAuthenticationEntryPoint.java	Updated to work with new security config
 
**Message Converter Fixes (Spring Boot 4.0 specific)**
GsonHttpMessageConverterConfig.java	Added ByteArrayHttpMessageConverter bean	Gson serializes byte[] (springdoc api-docs) as integer arrays, breaking Swagger UI
GsonHttpMessageConverterConfig.java	Added StringHttpMessageConverter bean	In Spring Boot 4.0, Gson converter takes priority over String converter, causing @RequestBody String parameters to fail
 
**JUnit 4 → JUnit Jupiter Migration**
CliOptionsUnitTests.java	@Before→@BeforeEach, @After→@AfterEach, @Ignore→@Disabled, JUnit 4 imports → Jupiter
CliUnitTests.java	@RunWith(MockitoJUnitRunner.class) → @ExtendWith(MockitoExtension.class), JUnit 4 → Jupiter
RMQHelperUnitTest.java	Same JUnit 4 → Jupiter migration
EiffelRemremCommonControllerUnitTest.java	Same, plus assertTrue argument order fix (JUnit 4: message first → Jupiter: condition first)

**MessageServiceRMQImplUnitTest.java	Same JUnit 4 → Jupiter migration**
EventTemplateHandlerTest.java	Same
TestEiffelRemRemPublishITTest.java	Same
 
**POM Structural Changes**
pom.xml (root)	Added logback.version, slf4j.version, maven-surefire-plugin.version properties
publish-cli/pom.xml	Cleaned up redundant version declarations
publish-service/pom.xml	Updated springdoc version, JUnit version
publish-common/pom.xml	Updated springdoc artifact, spring-ldap-core, JUnit version

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Shudhansu Shekhar shudhansu.shekhar.ext@ericsson.com
